### PR TITLE
Release/1.4.8

### DIFF
--- a/assets/css/admin-style.scss
+++ b/assets/css/admin-style.scss
@@ -103,43 +103,64 @@
 }
 
 // Fix width of the key column.
-.wp-list-table.keys {
-	.column-key {
-		width: 15%
+.wp-list-table {
+
+	// Keys table.
+	&.keys {
+		.column-key {
+			width: 15%
+		}
+
+		.wcsn-key-status {
+			color: #fff;
+			padding: 3px 10px;
+			font-size: 14px;
+			white-space: nowrap;
+			background-color: silver;
+			border-radius: 3px;
+			line-height: 1;
+			border: 1px solid transparent;
+
+			&.available {
+				color: #155724;
+				background-color: #d4edda;
+				border-color: #c3e6cb
+			}
+
+			&.pending {
+				color: #856404;
+				background-color: #fff3cd;
+				border-color: #ffeeba;
+			}
+
+			&.sold {
+				background: #cce5ff;
+				color: #004085;
+				border-color: #b8daff
+			}
+
+			&.cancelled {
+				color: #1b1e21;
+				background-color: #d6d8d9;
+				border-color: #c6c8ca
+			}
+
+		}
 	}
 
-	.wcsn-key-status {
-		color: #fff;
-		padding: 3px 10px;
-		font-size: 14px;
-		white-space: nowrap;
-		background-color: silver;
-		border-radius: 3px;
-		line-height: 1;
-		border: 1px solid transparent;
-
-		&.available {
-			color: #155724;
-			background-color: #d4edda;
-			border-color: #c3e6cb
+	&.stocks {
+		.column-action,
+		.column-stock {
+			width: 10%
 		}
 
-		&.pending {
-			color: #856404;
-			background-color: #fff3cd;
-			border-color: #ffeeba;
-		}
-		&.sold {
-			background: #cce5ff;
-			color: #004085;
-			border-color: #b8daff
-		}
-		&.cancelled {
-			color: #1b1e21;
-			background-color: #d6d8d9;
-			border-color: #c6c8ca
+		.column-source {
+			width: 20%;
 		}
 
+		.column-sku {
+			width: 25%;
+		}
 	}
 }
 

--- a/languages/wc-serial-numbers.pot
+++ b/languages/wc-serial-numbers.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPLv2+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Serial Numbers for WooCommerce 1.4.7\n"
+"Project-Id-Version: Serial Numbers for WooCommerce 1.4.8\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/plugins/wc-serial-numbers/\n"
-"POT-Creation-Date: 2023-04-03 15:15:20+00:00\n"
+"POT-Creation-Date: 2023-04-06 13:39:13+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -36,7 +36,7 @@ msgstr ""
 msgid "Go Pro"
 msgstr ""
 
-#: lib/Lib/Plugin.php:545 src/Admin/Settings.php:189
+#: lib/Lib/Plugin.php:545 src/Admin/Settings.php:188
 msgid "Documentation"
 msgstr ""
 
@@ -304,7 +304,7 @@ msgstr ""
 #: src/Admin/Admin.php:101 src/Admin/Menus.php:57 src/Admin/Menus.php:98
 #: src/Admin/Menus.php:99 src/Admin/Menus.php:434 src/Admin/Metaboxes.php:36
 #: src/Admin/Metaboxes.php:45 src/Admin/Metaboxes.php:226
-#: src/Deprecated/Functions.php:423
+#: src/Deprecated/Functions.php:424
 msgid "Serial Numbers"
 msgstr ""
 
@@ -324,7 +324,7 @@ msgstr ""
 
 #: src/Admin/ListTables/ActivationsTable.php:125
 #: src/Admin/ListTables/KeysTable.php:243
-#: src/Admin/ListTables/StockTable.php:98
+#: src/Admin/ListTables/StockTable.php:90
 msgid "Filter"
 msgstr ""
 
@@ -342,7 +342,7 @@ msgstr ""
 
 #: src/Admin/ListTables/ActivationsTable.php:190
 #: src/Admin/ListTables/KeysTable.php:310
-#: src/Admin/ListTables/StockTable.php:112
+#: src/Admin/ListTables/StockTable.php:104
 #: src/Admin/Views/html-api-actions.php:104
 #: src/Admin/Views/html-api-validation.php:108
 #: src/Admin/Views/html-edit-key.php:47 src/Deprecated/Functions.php:359
@@ -357,7 +357,8 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: src/Admin/ListTables/ActivationsTable.php:192 src/Shortcodes.php:143
+#: src/Admin/ListTables/ActivationsTable.php:192
+#: src/Admin/Views/html-api-actions.php:138 src/Shortcodes.php:143
 msgid "Platform"
 msgstr ""
 
@@ -482,18 +483,18 @@ msgid "ID: %d"
 msgstr ""
 
 #: src/Admin/ListTables/KeysTable.php:380
-#: src/Admin/ListTables/StockTable.php:169 src/Admin/Metaboxes.php:339
+#: src/Admin/ListTables/StockTable.php:185 src/Admin/Metaboxes.php:339
 msgid "Edit"
 msgstr ""
 
-#: src/Admin/ListTables/KeysTable.php:474
+#: src/Admin/ListTables/KeysTable.php:471
 msgid "<b>%s</b> Day <br><small>After purchase</small>"
 msgid_plural "<b>%s</b> Days <br><small>After purchase</small>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Admin/ListTables/KeysTable.php:474 src/Admin/Metaboxes.php:326
-#: src/Deprecated/Functions.php:471
+#: src/Admin/ListTables/KeysTable.php:471 src/Admin/Metaboxes.php:326
+#: src/Deprecated/Functions.php:472
 msgid "Lifetime"
 msgstr ""
 
@@ -517,21 +518,41 @@ msgstr ""
 msgid "stocks"
 msgstr ""
 
-#: src/Admin/ListTables/StockTable.php:76
+#: src/Admin/ListTables/StockTable.php:68
 msgid "No products selling serial keys from \"stock\" found."
 msgstr ""
 
-#: src/Admin/ListTables/StockTable.php:113
+#: src/Admin/ListTables/StockTable.php:105
 msgid "SKU"
 msgstr ""
 
-#: src/Admin/ListTables/StockTable.php:114 src/Admin/Menus.php:281
+#: src/Admin/ListTables/StockTable.php:106
+msgid "Source"
+msgstr ""
+
+#: src/Admin/ListTables/StockTable.php:107 src/Admin/Menus.php:281
 msgid "Stock"
 msgstr ""
 
-#: src/Admin/ListTables/StockTable.php:115
-#: src/Admin/Views/html-api-actions.php:147 src/Shortcodes.php:145
+#: src/Admin/ListTables/StockTable.php:108
+#: src/Admin/Views/html-api-actions.php:158 src/Shortcodes.php:145
 msgid "Action"
+msgstr ""
+
+#: src/Admin/ListTables/StockTable.php:159
+msgid "Manual"
+msgstr ""
+
+#: src/Admin/ListTables/StockTable.php:161
+msgid "Generator Rule"
+msgstr ""
+
+#: src/Admin/ListTables/StockTable.php:163
+msgid "Auto Generated"
+msgstr ""
+
+#: src/Admin/ListTables/StockTable.php:165
+msgid "Unknown"
 msgstr ""
 
 #: src/Admin/Menus.php:109 src/Admin/Menus.php:110
@@ -681,15 +702,22 @@ msgstr ""
 msgid "Actions"
 msgstr ""
 
-#: src/Admin/Metaboxes.php:319 src/Deprecated/Functions.php:464
+#: src/Admin/Metaboxes.php:319 src/Deprecated/Functions.php:465
 msgid "Unlimited"
 msgstr ""
 
-#: src/Admin/Notices.php:49
+#: src/Admin/Notices.php:51
 #. translators: %1$s: link to the plugin page, %2$s: link to the plugin page
 msgid ""
 "%s is not functional because you are using outdated version of the plugin, "
 "please update to the version 1.2.1 or higher."
+msgstr ""
+
+#: src/Admin/Notices.php:65
+#. translators: %1$s: link to the plugin page, %2$s: link to the plugin page
+msgid ""
+"Upgrade to %6$s to unlock the full potential of %5$s and avail a %1$s "
+"discount by using the promo code %2$s %3$s Upgrade Now %4$s."
 msgstr ""
 
 #: src/Admin/Orders.php:43 src/Admin/Orders.php:118
@@ -773,118 +801,112 @@ msgid "Hide serial key"
 msgstr ""
 
 #: src/Admin/Settings.php:78
-msgid ""
-"When keys are hidden, you can still view them by clicking on the show "
-"button."
-msgstr ""
-
-#: src/Admin/Settings.php:79
 msgid "Serial keys will be masked in the list table."
 msgstr ""
 
-#: src/Admin/Settings.php:84
+#: src/Admin/Settings.php:83
 msgid "Disable software support"
 msgstr ""
 
-#: src/Admin/Settings.php:86
+#: src/Admin/Settings.php:85
 msgid "Disable Software Licensing support & API functionalities."
 msgstr ""
 
-#: src/Admin/Settings.php:95
+#: src/Admin/Settings.php:94
 msgid "Stock notification"
 msgstr ""
 
-#: src/Admin/Settings.php:97
+#: src/Admin/Settings.php:96
 msgid "The following options affect how the stock notification will work."
 msgstr ""
 
-#: src/Admin/Settings.php:101
+#: src/Admin/Settings.php:100
 msgid "Stock notification email"
 msgstr ""
 
-#: src/Admin/Settings.php:103
+#: src/Admin/Settings.php:102
 msgid "Sends notification emails when product stock is low."
 msgstr ""
 
-#: src/Admin/Settings.php:109
+#: src/Admin/Settings.php:108
 msgid "Stock threshold"
 msgstr ""
 
-#: src/Admin/Settings.php:111
+#: src/Admin/Settings.php:110
 msgid ""
 "When the stock goes below the above number, it will send a notification "
 "email."
 msgstr ""
 
-#: src/Admin/Settings.php:116
+#: src/Admin/Settings.php:115
 msgid "Notification recipient email"
 msgstr ""
 
-#: src/Admin/Settings.php:118
+#: src/Admin/Settings.php:117
 msgid "The email address to be used for sending the email notifications."
 msgstr ""
 
-#: src/Admin/Settings.php:152
+#: src/Admin/Settings.php:151
 msgid "Create and assign license keys for WooCommerce variable products."
 msgstr ""
 
-#: src/Admin/Settings.php:153
+#: src/Admin/Settings.php:152
 msgid "Generate bulk license keys with your custom key generator rule."
 msgstr ""
 
-#: src/Admin/Settings.php:154
+#: src/Admin/Settings.php:153
 msgid "Random & sequential order for the generator rules."
 msgstr ""
 
-#: src/Admin/Settings.php:155
+#: src/Admin/Settings.php:154
 msgid "Automatic license key generator to auto-create & assign keys with orders."
 msgstr ""
 
-#: src/Admin/Settings.php:156
+#: src/Admin/Settings.php:155
 msgid "License key management option from the order page with required actions."
 msgstr ""
 
-#: src/Admin/Settings.php:157
+#: src/Admin/Settings.php:156
 msgid "Support for bulk import/export of license keys from/to CSV."
 msgstr ""
 
-#: src/Admin/Settings.php:158
+#: src/Admin/Settings.php:157
 msgid ""
 "Option to sell license keys even if there are no available keys in the "
 "stock."
 msgstr ""
 
-#: src/Admin/Settings.php:159
+#: src/Admin/Settings.php:158
 msgid "Custom deliverable quantity to deliver multiple keys with a single product."
 msgstr ""
 
-#: src/Admin/Settings.php:160
+#: src/Admin/Settings.php:159
 msgid ""
 "Manual delivery option to manually deliver license keys instead of "
 "automatic."
 msgstr ""
 
-#: src/Admin/Settings.php:161
+#: src/Admin/Settings.php:160
 msgid ""
 "Email Template to easily and quickly customize the order confirmation & low "
 "stock alert email."
 msgstr ""
 
-#: src/Admin/Settings.php:162
+#: src/Admin/Settings.php:161
 msgid "Many more ..."
 msgstr ""
 
-#: src/Admin/Settings.php:166
+#: src/Admin/Settings.php:165
 msgid "Want More?"
 msgstr ""
 
-#: src/Admin/Settings.php:167
+#: src/Admin/Settings.php:166
 msgid ""
 "This plugin offers a premium version which comes with the following "
 "features:"
 msgstr ""
 
-#: src/Admin/Settings.php:173
+#: src/Admin/Settings.php:172
 msgid "Upgrade to PRO"
 msgstr ""
 
@@ -1032,41 +1054,52 @@ msgid ""
 "key."
 msgstr ""
 
-#: src/Admin/Views/html-api-actions.php:137
+#: src/Admin/Views/html-api-actions.php:140
+msgid "Please enter a platform. e.g. Windows"
+msgstr ""
+
+#: src/Admin/Views/html-api-actions.php:142
+msgid ""
+"Optional field. Platform is the extra information of the activation record. "
+"You can use it to identify the platform of the activation."
+msgstr ""
+
+#: src/Admin/Views/html-api-actions.php:148
 #: src/Admin/Views/html-api-validation.php:131 src/Deprecated/Functions.php:361
 #: src/Shortcodes.php:43 src/Shortcodes.php:139
 msgid "Email"
 msgstr ""
 
-#: src/Admin/Views/html-api-actions.php:139
+#: src/Admin/Views/html-api-actions.php:150
 #: src/Admin/Views/html-api-validation.php:133
 msgid "Please enter a valid email address"
 msgstr ""
 
-#: src/Admin/Views/html-api-actions.php:141
+#: src/Admin/Views/html-api-actions.php:152
 msgid ""
-"Optional field. If email is provided, only serial key that are assigned to "
-"the email will be activated/deactivated otherwise ignored."
+"Optional field when duplicate key is off. If email is provided, only serial "
+"key that are assigned to the email will be activated/deactivated otherwise "
+"ignored."
 msgstr ""
 
-#: src/Admin/Views/html-api-actions.php:150 src/Shortcodes.php:152
+#: src/Admin/Views/html-api-actions.php:161 src/Shortcodes.php:152
 msgid "Activate"
 msgstr ""
 
-#: src/Admin/Views/html-api-actions.php:151 src/Shortcodes.php:153
+#: src/Admin/Views/html-api-actions.php:162 src/Shortcodes.php:153
 msgid "Deactivate"
 msgstr ""
 
-#: src/Admin/Views/html-api-actions.php:154
+#: src/Admin/Views/html-api-actions.php:165
 msgid "Select an action to perform on the serial key."
 msgstr ""
 
-#: src/Admin/Views/html-api-actions.php:159
+#: src/Admin/Views/html-api-actions.php:171
 #: src/Admin/Views/html-api-validation.php:140
 msgid "API Response"
 msgstr ""
 
-#: src/Admin/Views/html-api-actions.php:169 src/Shortcodes.php:146
+#: src/Admin/Views/html-api-actions.php:181 src/Shortcodes.php:146
 msgid "Submit"
 msgstr ""
 
@@ -1224,11 +1257,15 @@ msgstr ""
 msgid "Generate"
 msgstr ""
 
-#: src/Admin/Views/html-list-stock.php:23
-msgid "Note:"
+#: src/Admin/Views/html-list-stock.php:17
+msgid "Search"
 msgstr ""
 
 #: src/Admin/Views/html-list-stock.php:24
+msgid "Note:"
+msgstr ""
+
+#: src/Admin/Views/html-list-stock.php:25
 msgid ""
 "The following report displays a comprehensive list of products whose source "
 "for serial keys has been set to \"Manually Added.\"."
@@ -1259,7 +1296,7 @@ msgstr ""
 msgid "Expires"
 msgstr ""
 
-#: src/Deprecated/Functions.php:425
+#: src/Deprecated/Functions.php:426
 msgid "Order is waiting for serial numbers to be assigned."
 msgstr ""
 
@@ -1288,11 +1325,11 @@ msgstr ""
 msgid "Product id is invalid."
 msgstr ""
 
-#: src/Models/Key.php:486
+#: src/Models/Key.php:485
 msgid "Serial key already exists. Duplicate serial keys are not allowed."
 msgstr ""
 
-#: src/Models/Key.php:492
+#: src/Models/Key.php:491
 msgid "Order id is invalid."
 msgstr ""
 
@@ -1384,7 +1421,7 @@ msgstr ""
 msgid "Manually Added"
 msgstr ""
 
-#: src/functions.php:516
+#: src/functions.php:515
 #. translators: 1: product title 2: source and 3: Quantity
 msgid ""
 "There is not enough serial numbers for the product %1$s from selected "

--- a/languages/wc-serial-numbers.pot
+++ b/languages/wc-serial-numbers.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPLv2+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Serial Numbers for WooCommerce 1.4.6\n"
+"Project-Id-Version: Serial Numbers for WooCommerce 1.4.7\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/plugins/wc-serial-numbers/\n"
-"POT-Creation-Date: 2023-04-01 16:44:20+00:00\n"
+"POT-Creation-Date: 2023-04-03 15:15:20+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -324,6 +324,7 @@ msgstr ""
 
 #: src/Admin/ListTables/ActivationsTable.php:125
 #: src/Admin/ListTables/KeysTable.php:243
+#: src/Admin/ListTables/StockTable.php:98
 msgid "Filter"
 msgstr ""
 
@@ -341,7 +342,7 @@ msgstr ""
 
 #: src/Admin/ListTables/ActivationsTable.php:190
 #: src/Admin/ListTables/KeysTable.php:310
-#: src/Admin/ListTables/StockTable.php:100
+#: src/Admin/ListTables/StockTable.php:112
 #: src/Admin/Views/html-api-actions.php:104
 #: src/Admin/Views/html-api-validation.php:108
 #: src/Admin/Views/html-edit-key.php:47 src/Deprecated/Functions.php:359
@@ -481,7 +482,7 @@ msgid "ID: %d"
 msgstr ""
 
 #: src/Admin/ListTables/KeysTable.php:380
-#: src/Admin/ListTables/StockTable.php:157 src/Admin/Metaboxes.php:339
+#: src/Admin/ListTables/StockTable.php:169 src/Admin/Metaboxes.php:339
 msgid "Edit"
 msgstr ""
 
@@ -496,15 +497,15 @@ msgstr[1] ""
 msgid "Lifetime"
 msgstr ""
 
-#: src/Admin/ListTables/ListTable.php:130
+#: src/Admin/ListTables/ListTable.php:139
 msgid "Filter by order"
 msgstr ""
 
-#: src/Admin/ListTables/ListTable.php:153
+#: src/Admin/ListTables/ListTable.php:162
 msgid "Filter by product"
 msgstr ""
 
-#: src/Admin/ListTables/ListTable.php:176
+#: src/Admin/ListTables/ListTable.php:185
 msgid "Filter by customer"
 msgstr ""
 
@@ -516,19 +517,19 @@ msgstr ""
 msgid "stocks"
 msgstr ""
 
-#: src/Admin/ListTables/StockTable.php:80
+#: src/Admin/ListTables/StockTable.php:76
 msgid "No products selling serial keys from \"stock\" found."
 msgstr ""
 
-#: src/Admin/ListTables/StockTable.php:101
+#: src/Admin/ListTables/StockTable.php:113
 msgid "SKU"
 msgstr ""
 
-#: src/Admin/ListTables/StockTable.php:102 src/Admin/Menus.php:281
+#: src/Admin/ListTables/StockTable.php:114 src/Admin/Menus.php:281
 msgid "Stock"
 msgstr ""
 
-#: src/Admin/ListTables/StockTable.php:103
+#: src/Admin/ListTables/StockTable.php:115
 #: src/Admin/Views/html-api-actions.php:147 src/Shortcodes.php:145
 msgid "Action"
 msgstr ""
@@ -691,28 +692,32 @@ msgid ""
 "please update to the version 1.2.1 or higher."
 msgstr ""
 
-#: src/Admin/Orders.php:39
+#: src/Admin/Orders.php:43 src/Admin/Orders.php:118
 msgid "Add serial keys"
 msgstr ""
 
-#: src/Admin/Orders.php:40
+#: src/Admin/Orders.php:44 src/Admin/Orders.php:119
 msgid "Remove serial keys"
 msgstr ""
 
-#: src/Admin/Orders.php:59
+#: src/Admin/Orders.php:63
 msgid "Serial keys added successfully to the order."
 msgstr ""
 
-#: src/Admin/Orders.php:63
+#: src/Admin/Orders.php:67
 msgid "Serial keys removed successfully from the order."
 msgstr ""
 
-#: src/Admin/Orders.php:94
+#: src/Admin/Orders.php:98
 msgid "Order is fullfilled."
 msgstr ""
 
-#: src/Admin/Orders.php:97
+#: src/Admin/Orders.php:101
 msgid "Order is not fullfilled."
+msgstr ""
+
+#: src/Admin/Orders.php:147
+msgid "%d orders updated successfully."
 msgstr ""
 
 #: src/Admin/Settings.php:25
@@ -1217,6 +1222,16 @@ msgstr ""
 
 #: src/Admin/Views/html-list-keys.php:33
 msgid "Generate"
+msgstr ""
+
+#: src/Admin/Views/html-list-stock.php:23
+msgid "Note:"
+msgstr ""
+
+#: src/Admin/Views/html-list-stock.php:24
+msgid ""
+"The following report displays a comprehensive list of products whose source "
+"for serial keys has been set to \"Manually Added.\"."
 msgstr ""
 
 #: src/Ajax.php:190

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc-serial-numbers",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-serial-numbers",
-      "version": "1.4.6",
+      "version": "1.4.7",
       "license": "GPL-3.0+",
       "devDependencies": {
         "@lodder/time-grunt": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wc-serial-numbers",
   "title": "Serial Numbers for WooCommerce",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "The best WooCommerce extension to sell license & serial keys, gift cards and other secret numbers!",
   "homepage": "https://pluginever.com/plugins/wc-serial-numbers/",
   "license": "GPL-3.0+",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wc-serial-numbers",
   "title": "Serial Numbers for WooCommerce",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "The best WooCommerce extension to sell license & serial keys, gift cards and other secret numbers!",
   "homepage": "https://pluginever.com/plugins/wc-serial-numbers/",
   "license": "GPL-3.0+",

--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Sell and manage license keys/serial numbers on your WooCommerce store with ease.
 
 == Description ==
-**[Serial Numbers for WooCommerce](https://pluginever.com/plugins/woocommerce-serial-numbers-pro/?utm_source=product-page-wordpress.org&utm_medium=product-page-wordpress.org&utm_campaign=product-page-wordpress.org)** is the most powerful license manager plugin for WooCommerce designed to help online store owners manage product licenses and activations efficiently. This plugin works seamlessly with WooCommerce and provides an easy-to-use interface to manage licenses, assign license keys to products, and track customer activations. 
+**[Serial Numbers for WooCommerce](https://pluginever.com/plugins/woocommerce-serial-numbers-pro/?utm_source=product-page-wordpress.org&utm_medium=product-page-wordpress.org&utm_campaign=product-page-wordpress.org)** is the most powerful license manager plugin for WooCommerce designed to help online store owners manage product licenses and activations efficiently. This plugin works seamlessly with WooCommerce and provides an easy-to-use interface to manage licenses, assign license keys to products, and track customer activations.
 
 Serial Numbers for WooCommerce is an essential tool for any online store owner looking to streamline license management and improve customer experience. With its intuitive interface and powerful features, this plugin makes it easy to manage licenses, reduce piracy, and grow your business.
 
@@ -197,6 +197,11 @@ Serial Numbers for WooCommerce has a dedicated page for Software API. [You can l
 
 
 == Changelog ==
+= 1.4.7 (3 April 2023) =
+* Fix : Search key by customer name is not working.
+* Fix : Stock report is showing only 20 records.
+* Enhance: Order table add bulk action to add/remove serial keys.
+
 = 1.4.6 (1 April 2023) =
 * Enhance: Enhanced API implementation.
 * Enhance: Update Serial Number statues.

--- a/readme.txt
+++ b/readme.txt
@@ -201,6 +201,7 @@ Serial Numbers for WooCommerce has a dedicated page for Software API. [You can l
 * Fix : Search key by customer name is not working.
 * Fix : Stock report is showing only 20 records.
 * Enhance: Order table add bulk action to add/remove serial keys.
+* Enhance : Add product filter in the stock report table.
 
 = 1.4.6 (1 April 2023) =
 * Enhance: Enhanced API implementation.

--- a/readme.txt
+++ b/readme.txt
@@ -197,6 +197,15 @@ Serial Numbers for WooCommerce has a dedicated page for Software API. [You can l
 
 
 == Changelog ==
+= 1.4.8 (6 April 2023) =
+* Fix : Only 20 records are showing when bought more than 20 serial keys.
+* Fix : Serial keys assigned only for first 2 products when bought more than 2 products.
+* Fix : Action 'Edit' is not working for variable products on Report menu.
+* Enhance: Add search option for serial number in the stock report table.
+* Enhance: Fix duplicate key issue when importing.
+* Enhance: UI improvements.
+
+
 = 1.4.7 (3 April 2023) =
 * Fix : Search key by customer name is not working.
 * Fix : Stock report is showing only 20 records.

--- a/src/API.php
+++ b/src/API.php
@@ -126,7 +126,7 @@ class API extends Lib\Singleton {
 		}
 
 		// If email is provided, check if it is valid.
-		if ( $email && $order->get_billing_email() !== $email ) {
+		if ( ( $email || wcsn_is_duplicate_key_allowed() ) && $order->get_billing_email() !== $email ) {
 			wp_send_json_error(
 				array(
 					'code'    => 'invalid_email',

--- a/src/Admin/ListTables/KeysTable.php
+++ b/src/Admin/ListTables/KeysTable.php
@@ -393,10 +393,7 @@ class KeysTable extends ListTable {
 	 */
 	protected function column_product( $item ) {
 		$product     = wc_get_product( $item->product_id );
-		$post_parent = wp_get_post_parent_id( $item->product_id );
-		$post_id     = $post_parent ? $post_parent : $item->product_id;
-
-		return empty( $item->product_id ) || empty( $product ) ? '&mdash;' : sprintf( '<a href="%s" target="_blank">#%d - %s</a>', get_edit_post_link( $post_id ), $product->get_id(), $product->get_formatted_name() );
+		return empty( $item->product_id ) || empty( $product ) ? '&mdash;' : sprintf( '<a href="%s" target="_blank">#%d - %s</a>', wcsn_get_edit_product_link( $product->get_id() ), $product->get_id(), $product->get_formatted_name() );
 	}
 
 	/**

--- a/src/Admin/ListTables/ListTable.php
+++ b/src/Admin/ListTables/ListTable.php
@@ -185,7 +185,7 @@ class ListTable extends \WP_List_Table {
 			<?php esc_html_e( 'Filter by customer', 'wc-serial-numbers' ); ?>
 		</label>
 		<select class="wcsn_search_customer" name="customer_id" id="filter-by-customer-id">
-			<?php if ( ! empty( $customer ) ) : ?>
+			<?php if ( $customer->get_id() ) : ?>
 				<option selected="selected" value="<?php echo esc_attr( $customer->get_id() ); ?>">
 					<?php echo esc_html( sprintf( '%s (%s)', $customer->get_first_name() . ' ' . $customer->get_last_name(), $customer->get_email() ) ); ?>
 				</option>

--- a/src/Admin/ListTables/ListTable.php
+++ b/src/Admin/ListTables/ListTable.php
@@ -17,6 +17,15 @@ if ( ! class_exists( '\WP_List_Table' ) ) {
  */
 class ListTable extends \WP_List_Table {
 	/**
+	 *
+	 * Total number of items
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	public $total_count = 0;
+
+	/**
 	 * Get a request var, or return the default if not set.
 	 *
 	 * @param string $var Request var name.
@@ -170,7 +179,7 @@ class ListTable extends \WP_List_Table {
 	 */
 	public function customer_dropdown() {
 		$customer_id = filter_input( INPUT_GET, 'customer_id', FILTER_SANITIZE_NUMBER_INT );
-		$customer    = get_user_by( 'ID', $customer_id );
+		$customer    = new \WC_Customer( $customer_id );
 		?>
 		<label for="filter-by-customer-id" class="screen-reader-text">
 			<?php esc_html_e( 'Filter by customer', 'wc-serial-numbers' ); ?>
@@ -178,7 +187,7 @@ class ListTable extends \WP_List_Table {
 		<select class="wcsn_search_customer" name="customer_id" id="filter-by-customer-id">
 			<?php if ( ! empty( $customer ) ) : ?>
 				<option selected="selected" value="<?php echo esc_attr( $customer->get_id() ); ?>">
-					<?php echo esc_html( $customer->get_name() ); ?>
+					<?php echo esc_html( sprintf( '%s (%s)', $customer->get_first_name() . ' ' . $customer->get_last_name(), $customer->get_email() ) ); ?>
 				</option>
 			<?php endif; ?>
 		</select>

--- a/src/Admin/ListTables/StockTable.php
+++ b/src/Admin/ListTables/StockTable.php
@@ -30,7 +30,7 @@ class StockTable extends ListTable {
 	 * @since 1.4.6
 	 */
 	public function prepare_items() {
-		$per_page              = $this->get_items_per_page( 'wcsn_stocks_per_page' );
+		$per_page              = 20;
 		$columns               = $this->get_columns();
 		$hidden                = [];
 		$sortable              = $this->get_sortable_columns();
@@ -40,16 +40,13 @@ class StockTable extends ListTable {
 		$order                 = isset( $_GET['order'] ) ? sanitize_key( $_GET['order'] ) : 'desc';
 		$search                = isset( $_GET['s'] ) ? sanitize_text_field( $_GET['s'] ) : null;
 		$product_id            = isset( $_GET['product_id'] ) ? absint( $_GET['product_id'] ) : '';
-		$order_id              = isset( $_GET['order_id'] ) ? absint( $_GET['order_id'] ) : '';
-		$customer_id           = isset( $_GET['customer_id'] ) ? absint( $_GET['customer_id'] ) : '';
-		$id                    = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : '';
 
 		$query_args = array(
 			'posts_per_page' => $per_page,
 			'fields'         => 'ids',
 			'search'         => $search,
 			'paged'          => $current_page,
-			'post__in'       => $id ? wp_parse_id_list( $id ) : array(),
+			'post__in'       => $product_id ? wp_parse_id_list( $product_id ) : array(),
 			'meta_query'     => array( // @codingStandardsIgnoreLine
 				'relation' => 'AND',
 				array(
@@ -63,7 +60,6 @@ class StockTable extends ListTable {
 
 		$this->items       = array_map( 'wc_get_product', $post_ids );
 		$this->total_count = wcsn_get_products( array_merge( $query_args, array( 'count' => true ) ) );
-
 		$this->set_pagination_args(
 			array(
 				'total_items' => $this->total_count,
@@ -88,6 +84,22 @@ class StockTable extends ListTable {
 	 */
 	public function get_views() {
 		return parent::get_views();
+	}
+
+	/**
+	 * Adds the order and product filters to the licenses list.
+	 *
+	 * @param string $which The location of the extra table nav markup: 'top' or 'bottom'.
+	 */
+	protected function extra_tablenav( $which ) {
+		if ( $which === 'top' ) {
+			echo '<div class="alignleft actions">';
+			$this->product_dropdown();
+			submit_button( __( 'Filter', 'wc-serial-numbers' ), '', 'filter-action', false );
+
+
+			echo '</div>';
+		}
 	}
 
 	/**

--- a/src/Admin/Notices.php
+++ b/src/Admin/Notices.php
@@ -16,8 +16,8 @@ class Notices extends Singleton {
 	/**
 	 * Notices container.
 	 *
-	 * @var array
 	 * @since 1.0.0
+	 * @var array
 	 */
 	protected $notices = array();
 
@@ -29,6 +29,8 @@ class Notices extends Singleton {
 	protected function __construct() {
 		add_action( 'admin_init', [ $this, 'add_notices' ] );
 		add_action( 'admin_notices', [ $this, 'output_notices' ] );
+		add_action( 'wp_ajax_wc_serial_numbers_dismiss_notice', [ $this, 'dismiss_notice' ] );
+		add_action( 'admin_footer', [ $this, 'add_notice_script' ] );
 	}
 
 	/**
@@ -38,16 +40,35 @@ class Notices extends Singleton {
 	 */
 	public function add_notices() {
 		$is_outdated_pro = defined( 'WC_SERIAL_NUMBER_PRO_PLUGIN_VERSION' ) && version_compare( WC_SERIAL_NUMBER_PRO_PLUGIN_VERSION, '1.2.1', '<' );
-		if( ! $is_outdated_pro ) {
+		if ( ! $is_outdated_pro ) {
 			$is_outdated_pro = function_exists( 'wc_serial_numbers_pro' ) && is_callable( [ wc_serial_numbers_pro(), 'get_version' ] ) && wc_serial_numbers_pro()->get_version() && version_compare( wc_serial_numbers_pro()->get_version(), '1.2.1', '<' );
 		}
 		if ( $is_outdated_pro ) {
 			$this->notices[] = array(
-				'type'    => 'error',
+				'type'    => 'error', // add notice-alt and notice-large class.
 				'message' => sprintf(
 				/* translators: %1$s: link to the plugin page, %2$s: link to the plugin page */
 					__( '%s is not functional because you are using outdated version of the plugin, please update to the version 1.2.1 or higher.', 'wc-serial-numbers' ),
 					'<a href="' . esc_url( wc_serial_numbers()->get_data( 'premium_url' ) ) . '" target="_blank">WooCommerce Serial Numbers Pro</a>'
+				),
+			);
+		}
+
+		if ( ! $this->is_notice_dismissed( 'wc_serial_numbers_upgrade_to_pro_wcsnpro10' ) ) {
+			$this->notices[] = array(
+				'type'        => 'info',
+				'classes'     => 'notice-alt notice-large',
+				'dismissible' => true,
+				'id'          => 'wc_serial_numbers_upgrade_to_pro_wcsnpro10',
+				'message'     => sprintf(
+				/* translators: %1$s: link to the plugin page, %2$s: link to the plugin page */
+					__( 'Upgrade to %6$s to unlock the full potential of %5$s and avail a %1$s discount by using the promo code %2$s %3$s Upgrade Now %4$s.', 'wc-serial-numbers' ),
+					'<strong>10%</strong>',
+					'<strong>WCSNPRO10</strong>',
+					'<a href="' . esc_url( wc_serial_numbers()->get_premium_url() ) . '" target="_blank">',
+					'</a>',
+					'<strong>' . wc_serial_numbers()->get_name() . '</strong>',
+					'<strong>PRO</strong>'
 				),
 			);
 		}
@@ -60,11 +81,79 @@ class Notices extends Singleton {
 	 */
 	public function output_notices() {
 		foreach ( $this->notices as $notice ) {
+			$notice = wp_parse_args( $notice, array(
+				'id'          => wp_generate_password( 12, false ),
+				'type'        => 'info',
+				'classes'     => '',
+				'message'     => '',
+				'dismissible' => false,
+			) );
+
+			$notice_classes = array( 'notice', 'notice-' . $notice['type'] );
+			if ( $notice['dismissible'] ) {
+				$notice_classes[] = 'is-dismissible';
+			}
+			if ( $notice['classes'] ) {
+				$notice_classes[] = $notice['classes'];
+			}
 			?>
-			<div class="notice notice-<?php echo esc_attr( $notice['type'] ); ?>">
+			<div class="wcsn-notice <?php echo esc_attr( implode( ' ', $notice_classes ) ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wc_serial_numbers_dismiss_notice' ) ); ?>" data-notice-id="<?php echo esc_attr( $notice['id'] ); ?>">
 				<p><?php echo wp_kses_post( $notice['message'] ); ?></p>
 			</div>
 			<?php
 		}
+	}
+
+	/**
+	 * Dismiss notice.
+	 *
+	 * @since 1.0.0
+	 */
+	public function dismiss_notice() {
+		check_ajax_referer( 'wc_serial_numbers_dismiss_notice', 'nonce' );
+		$notice_id = isset( $_POST['notice_id'] ) ? sanitize_text_field( wp_unslash( $_POST['notice_id'] ) ) : '';
+		if ( $notice_id ) {
+			update_option( 'wc_serial_numbers_dismissed_notices', array_merge( get_option( 'wc_serial_numbers_dismissed_notices', array() ), array( $notice_id ) ) );
+		}
+		wp_die();
+	}
+
+	/**
+	 * Check if notice is dismissed.
+	 *
+	 * @param string $notice_id Notice ID.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
+	public function is_notice_dismissed( $notice_id ) {
+		return in_array( $notice_id, get_option( 'wc_serial_numbers_dismissed_notices', array() ), true );
+	}
+
+	/**
+	 * Add notice script.
+	 *
+	 * @since 1.0.0
+	 */
+	public function add_notice_script() {
+		?>
+		<script type="text/javascript">
+			jQuery(function ($) {
+				$('.wcsn-notice').on('click', '.notice-dismiss', function () {
+					var $notice = $(this).closest('.wcsn-notice');
+					$.ajax({
+						url: '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>',
+						method: 'POST',
+						data: {
+							action: 'wc_serial_numbers_dismiss_notice',
+							nonce: $notice.data('nonce'),
+							notice_id: $notice.data('notice-id'),
+						},
+					});
+				});
+			});
+		</script>
+		<?php
 	}
 }

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -75,7 +75,6 @@ class Settings extends Lib\Settings {
 					[
 						'title'    => __( 'Hide serial key', 'wc-serial-numbers' ),
 						'id'       => 'wc_serial_numbers_hide_serial_number',
-						'desc_tip' => __( 'When keys are hidden, you can still view them by clicking on the show button.', 'wc-serial-numbers' ),
 						'desc'     => __( 'Serial keys will be masked in the list table.', 'wc-serial-numbers' ),
 						'default'  => 'yes',
 						'type'     => 'checkbox',

--- a/src/Admin/Views/html-api-actions.php
+++ b/src/Admin/Views/html-api-actions.php
@@ -133,12 +133,23 @@ $api_url = add_query_arg(
 					</td>
 				</tr>
 
+				<!--platform-->
+				<tr>
+					<th scope="row"><label for="platform"><?php esc_html_e( 'Platform', 'wc-serial-numbers' ); ?></label></th>
+					<td>
+						<input type="text" name="platform" id="platform" placeholder="<?php esc_attr_e( 'Please enter a platform. e.g. Windows', 'wc-serial-numbers' ); ?>"/>
+						<p class="description">
+							<?php esc_html_e( 'Optional field. Platform is the extra information of the activation record. You can use it to identify the platform of the activation.', 'wc-serial-numbers' ); ?>
+						</p>
+					</td>
+				</tr>
+
 				<tr>
 					<th scope="row"><label for="email"><?php esc_html_e( 'Email', 'wc-serial-numbers' ); ?></label></th>
 					<td>
 						<input type="email" name="email" id="email" placeholder="<?php esc_attr_e( 'Please enter a valid email address', 'wc-serial-numbers' ); ?>">
 						<p class="description">
-							<?php esc_html_e( 'Optional field. If email is provided, only serial key that are assigned to the email will be activated/deactivated otherwise ignored.', 'wc-serial-numbers' ); ?>
+							<?php esc_html_e( 'Optional field when duplicate key is off. If email is provided, only serial key that are assigned to the email will be activated/deactivated otherwise ignored.', 'wc-serial-numbers' ); ?>
 						</p>
 					</td>
 				</tr>
@@ -155,6 +166,7 @@ $api_url = add_query_arg(
 						</p>
 					</td>
 				</tr>
+
 				<tr>
 					<th scope="row"><label><?php esc_html_e( 'API Response', 'wc-serial-numbers' ); ?></label></th>
 					<td class="code">

--- a/src/Admin/Views/html-list-stock.php
+++ b/src/Admin/Views/html-list-stock.php
@@ -13,7 +13,8 @@ $list_table = new WooCommerceSerialNumbers\Admin\ListTables\StockTable();
 <form id="wcsn-stock-table" method="get">
 	<?php
 	$list_table->prepare_items();
-	//$list_table->views();
+	$list_table->views();
+	$list_table->search_box( __( 'Search', 'wc-serial-numbers' ), 'key' );
 	$list_table->display();
 	?>
 	<input type="hidden" name="tab" value="stock">

--- a/src/Admin/Views/html-list-stock.php
+++ b/src/Admin/Views/html-list-stock.php
@@ -19,3 +19,7 @@ $list_table = new WooCommerceSerialNumbers\Admin\ListTables\StockTable();
 	<input type="hidden" name="tab" value="stock">
 	<input type="hidden" name="page" value="wc-serial-numbers-reports">
 </form>
+<p class="description">
+	<strong><?php esc_html_e( 'Note:', 'wc-serial-numbers' ); ?></strong>
+	<?php esc_html_e( 'The following report displays a comprehensive list of products whose source for serial keys has been set to "Manually Added.".', 'wc-serial-numbers' ); ?>
+</p>

--- a/src/Deprecated/Functions.php
+++ b/src/Deprecated/Functions.php
@@ -393,7 +393,7 @@ function wc_serial_numbers_get_stock_quantity( $product_id ) {
 /**
  * Get order table.
  *
- * @param bool  $return
+ * @param bool $return
  *
  * @param      $order
  *
@@ -417,6 +417,7 @@ function wc_serial_numbers_get_order_table( $order, $return = false ) {
 	$serial_numbers = wcsn_get_keys(
 		array(
 			'order_id' => $order_id,
+			'limit'    => - 1,
 		)
 	);
 
@@ -430,20 +431,20 @@ function wc_serial_numbers_get_order_table( $order, $return = false ) {
 	ob_start();
 	$columns = wc_serial_numbers_get_order_table_columns();
 	?>
-	<table
-		class="woocommerce-table woocommerce-table--order-details shop_table order_details wc-serial-numbers-order-items"
-		style="width: 100%; margin-bottom: 40px;"
-		cellspacing="0" cellpadding="6" border="1">
-		<thead>
-		<tr>
+    <table
+            class="woocommerce-table woocommerce-table--order-details shop_table order_details wc-serial-numbers-order-items"
+            style="width: 100%; margin-bottom: 40px;"
+            cellspacing="0" cellpadding="6" border="1">
+        <thead>
+        <tr>
 			<?php
 			foreach ( $columns as $key => $label ) {
 				echo sprintf( '<th class="td %s" scope="col" style="text-align:left;">%s</th>', sanitize_html_class( $key ), $label );
 			}
 			?>
-		</tr>
-		</thead>
-		<tbody>
+        </tr>
+        </thead>
+        <tbody>
 		<?php
 		foreach ( $serial_numbers as $serial_number ) {
 			echo '<tr>';
@@ -483,8 +484,8 @@ function wc_serial_numbers_get_order_table( $order, $return = false ) {
 		}
 		?>
 
-		</tbody>
-	</table>
+        </tbody>
+    </table>
 	<?php
 	$output = ob_get_contents();
 	ob_get_clean();

--- a/src/Models/Key.php
+++ b/src/Models/Key.php
@@ -478,9 +478,8 @@ class Key extends Model {
 		}
 
 		// Duplicate serial key is not allowed.
-		if ( ! apply_filters( 'wc_serial_numbers_allow_duplicate_serial_number', false ) ) {
-			$encrypted_key = wc_serial_numbers_encrypt_key( $this->get_serial_key() );
-			$existing      = self::get( $encrypted_key, 'serial_key' );
+		if ( ! wcsn_is_duplicate_key_allowed() ) {
+			$existing      = self::get( $this->get_serial_key(), 'serial_key' );
 
 			if ( $existing && $existing->get_id() !== $this->get_id() ) {
 				return new \WP_Error( 'invalid-data', __( 'Serial key already exists. Duplicate serial keys are not allowed.', 'wc-serial-numbers' ) );

--- a/src/Models/Key.php
+++ b/src/Models/Key.php
@@ -567,9 +567,9 @@ class Key extends Model {
 			);
 
 			if ( ! empty( $order_ids ) ) {
-				$clauses['where'][] = " AND {$this->table_alias}.order_id IN (" . implode( ',', $order_ids ) . ')';
+				$clauses['where'] .= " AND {$this->table_alias}.order_id IN (" . implode( ',', $order_ids ) . ')';
 			} else {
-				$clauses['where'][] = ' AND 0';
+				$clauses['where'] .= ' AND 0';
 			}
 		}
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -468,7 +468,6 @@ function wcsn_order_update_keys( $order_id ) {
 		 */
 		do_action( 'wc_serial_numbers_pre_add_order_keys', $order_id, $line_items, $order_status );
 		$added = 0;
-
 		foreach ( $line_items as $k => $item ) {
 			if ( ! apply_filters( 'wc_serial_numbers_add_order_item_keys', true, $item, $order_id ) ) {
 				continue;
@@ -545,12 +544,10 @@ function wcsn_order_update_keys( $order_id ) {
 			 * @param int $order_id Order ID.
 			 * @param int $needed_count Needed count.
 			 */
-			do_action( 'wc_serial_numbers_add_order_item_keys', $item, $order_id, $needed_count );
+			do_action( 'wc_serial_numbers_added_order_item_keys', $item, $order_id, $needed_count );
 
 			// Deprecated. use wc_serial_numbers_pre_order_add_keys instead. Will be removed in 1.5.0.
 			do_action( 'wc_serial_numbers_order_connect_serial_numbers', $order_id, count( $keys ) );
-
-			return;
 		}
 
 		if ( $added > 0 ) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -825,3 +825,22 @@ function wcsn_get_product_stock( $product_id ) {
 
 	return 0;
 }
+
+/**
+ * Get product edit link.
+ *
+ * @param int $product_id Product ID.
+ *
+ * @since 1.4.8
+ * @retun string
+ */
+function wcsn_get_edit_product_link( $product_id  ){
+	// If the product is a variation, get the parent product.
+
+	$product = wc_get_product( $product_id );
+	if ( $product && $product->is_type( 'variation' ) ) {
+		$product_id = $product->get_parent_id();
+	}
+
+	return get_edit_post_link( $product_id );
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -161,7 +161,7 @@ function wcsn_get_order_object( $order ) {
  * @since 1.4.6
  * @return Key|WP_Error object on success, WP_Error object on failure.
  */
-function wcsn_insert_key( $args, $wp_error = false ) {
+function wcsn_insert_key( $args, $wp_error = true ) {
 	return Key::insert( $args, $wp_error );
 }
 
@@ -834,7 +834,7 @@ function wcsn_get_product_stock( $product_id ) {
  * @since 1.4.8
  * @retun string
  */
-function wcsn_get_edit_product_link( $product_id  ){
+function wcsn_get_edit_product_link( $product_id ) {
 	// If the product is a variation, get the parent product.
 
 	$product = wc_get_product( $product_id );
@@ -843,4 +843,15 @@ function wcsn_get_edit_product_link( $product_id  ){
 	}
 
 	return get_edit_post_link( $product_id );
+}
+
+
+/**
+ * Is duplicate serial key allowed.
+ *
+ * @since 1.4.8
+ * @return bool
+ */
+function wcsn_is_duplicate_key_allowed() {
+	return apply_filters( 'wc_serial_numbers_allow_duplicate_key', false );
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -773,7 +773,7 @@ function wcsn_decrypt_key( $key ) {
  *
  * @return array
  */
-function wcsn_get_stocks_count( $stock_limit = null, $force = false ) {
+function wcsn_get_stocks_count( $stock_limit = null, $force = true ) {
 	$transient_key = 'wcsn_products_stock_count';
 	$counts        = get_transient( $transient_key );
 

--- a/wc-serial-numbers.php
+++ b/wc-serial-numbers.php
@@ -3,7 +3,7 @@
  * Plugin Name: Serial Numbers for WooCommerce
  * Plugin URI:  https://www.pluginever.com/plugins/wocommerce-serial-numbers-pro/
  * Description: The best WooCommerce extension to sell license & serial keys, gift cards and other secret numbers!
- * Version:     1.4.6
+ * Version:     1.4.7
  * Author:      PluginEver
  * Author URI:  http://pluginever.com
  * Donate link: https://pluginever.com/contact

--- a/wc-serial-numbers.php
+++ b/wc-serial-numbers.php
@@ -3,7 +3,7 @@
  * Plugin Name: Serial Numbers for WooCommerce
  * Plugin URI:  https://www.pluginever.com/plugins/wocommerce-serial-numbers-pro/
  * Description: The best WooCommerce extension to sell license & serial keys, gift cards and other secret numbers!
- * Version:     1.4.7
+ * Version:     1.4.8
  * Author:      PluginEver
  * Author URI:  http://pluginever.com
  * Donate link: https://pluginever.com/contact


### PR DESCRIPTION
== Changelog ==
= 1.4.8 (6 April 2023) =
* Fix : Only 20 records are showing when bought more than 20 serial keys.
* Fix : Serial keys assigned only for first 2 products when bought more than 2 products.
* Fix : Action 'Edit' is not working for variable products on Report menu.
* Enhance: Add search option for serial number in the stock report table.
* Enhance: Fix duplicate key issue when importing.
* Enhance: UI improvements.