### PR TITLE
Change plugin name according to the new naming style

### DIFF
--- a/wc-serial-numbers.php
+++ b/wc-serial-numbers.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Serial Numbers for WooCommerce
+ * Plugin Name: WC Serial Numbers
  * Plugin URI:  https://www.pluginever.com/plugins/wocommerce-serial-numbers-pro/
  * Description: Sell and manage license keys/ serial numbers/ secret keys easily within your WooCommerce store.
  * Version:     1.5.9


### PR DESCRIPTION
Fix https://github.com/pluginever/wc-serial-numbers/issues/376