### PR TITLE
Add cart_product to allow_backorder filter

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -174,7 +174,7 @@ In the search field type "Serial Numbers" and click Search Plugins. Once you hav
 
 = Manual installation =
 
-1. Upload the plugin files to the `/wp-content/plugins/wc-serial-numbers` directory, or install the plugin through the WordPress plugins screen directly.
+1. Upload the plugin files to the `/wp-content/plugins/wc-serail-numbers` directory, or install the plugin through the WordPress plugins screen directly.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 = Updating =

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === WC Serial Numbers - Ultimate License Manager Plugin for Selling, Licensing & Securely Delivering Digital Products with WooCommerce ===
 Contributors: pluginever, manikmist09, b-07
-Tags: license manager, license, license number, serial number, activation number, key, serial key, license key, activation key, product key, serial code, license code, activation code digital product key, digital license, product license, software license, software license key, software activation, license key for digital products, product identification number, digital product license, virtual product key, virtual product license, subscription product license, serial number generator, unique number, license key generator, auto generate serial number, woocommerce, woocommerce license manager, woocommerce key, sell code
+Tags: license manager, license, license number, serial number, activation number, key, serial key, license key, activation key, product key, serial code, license code, activation code, digital, digital downloads, digital product key, digital license, product license, software license, software license key, software activation, license key for digital products, digital product license, virtual product key, virtual product license, subscription product license, license key generator, woocommerce, woocommerce license manager, woocommerce key, sell code
 Requires at least: 5.0
 Tested up to: 6.3
 Requires PHP: 5.6
-Stable tag: 1.5.9
+Stable tag: 1.6.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -174,7 +174,7 @@ In the search field type "Serial Numbers" and click Search Plugins. Once you hav
 
 = Manual installation =
 
-1. Upload the plugin files to the `/wp-content/plugins/wc-serail-numbers` directory, or install the plugin through the WordPress plugins screen directly.
+1. Upload the plugin files to the `/wp-content/plugins/wc-serial-numbers` directory, or install the plugin through the WordPress plugins screen directly.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 = Updating =

--- a/src/Orders.php
+++ b/src/Orders.php
@@ -43,13 +43,13 @@ class Orders {
 	 * @return void
 	 */
 	public static function validate_checkout() {
-		$car_products = WC()->cart->get_cart_contents();
-		foreach ( $car_products as $id => $cart_product ) {
+		$cart_products = WC()->cart->get_cart_contents();
+		foreach ( $cart_products as $id => $cart_product ) {
 			/** @var \WC_Product $product */
 			$product         = $cart_product['data'];
 			$product_id      = $product->get_id();
 			$quantity        = $cart_product['quantity'];
-			$allow_backorder = apply_filters( 'wc_serial_numbers_allow_backorder', false, $product_id );
+			$allow_backorder = apply_filters( 'wc_serial_numbers_allow_backorder', false, $product_id, $cart_product );
 
 			if ( wcsn_is_product_enabled( $product_id ) && ! $allow_backorder ) {
 				$per_item_quantity = absint( apply_filters( 'wc_serial_numbers_per_product_delivery_qty', 1, $product_id ) );


### PR DESCRIPTION
I've been updating my custom plugin to work with the new wcsn codebase, and been very happy so far.  The new object model and hooks have allowed me to move most of my customization into my own plugin, reducing to changes I need to make in the wcsn code.

One place this doesn't quite work is the `wc_serial_numbers_allow_backorder` hook.  I need to be able to allow back-orders (i.e., bypass the inventory check) based on cart metadata, but only the product_id is passed via the hook.  I could search the cart myself for that product_id, but the same product_id can appear multiple times in the cart (the same product_id can appear as a separate lines with different metadata), so I need to know exactly which cart entry wcsn is checking when the filter is called.

Therefore, it would be very helpful if the $cart_product is could be provided in the filter call.  I'm not sure if this would cause issues with the existing hook API, but I'm under the impression that arguments can be added to hooks without breaking code that expects fewer, so I don't believe so.

This patch also includes a typo fix to a private variable name in the function.  I'm not sure if you generally fix those, or leave them alone to keep the codebase stable.  If the latter, I won't submit patches to those in the future.