### PR TITLE
Optionally disable encryption when saving keys

### DIFF
--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -88,6 +88,14 @@ class Settings extends Lib\Settings {
 						'type'    => 'checkbox',
 					],
 					[
+						'title' => __( 'Disable Encryption', 'wc-serial-numbers' ),
+						'id'    => 'wc_serial_numbers_disable_encryption',
+						'desc'  => __( 'Store new serial keys in database as plaintext.', 'wc-serial-numbers' ),
+						'desc_tip' => __( 'If you enable this option, new keys will be stored unencrypted.  Existing keys will not be altered.', 'wc-serial-numbers' ),
+						'default' => 'no',
+						'type'  => 'checkbox',
+					],
+					[
 						'type' => 'sectionend',
 						'id'   => 'section_serial_numbers',
 					],

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -88,10 +88,10 @@ class Settings extends Lib\Settings {
 						'type'    => 'checkbox',
 					],
 					[
-						'title' => __( 'Disable Encryption', 'wc-serial-numbers' ),
+						'title' => __( 'Disable encryption', 'wc-serial-numbers' ),
 						'id'    => 'wc_serial_numbers_disable_encryption',
-						'desc'  => __( 'Store new serial keys in database as plaintext.', 'wc-serial-numbers' ),
-						'desc_tip' => __( 'If you enable this option, new keys will be stored unencrypted.  Existing keys will not be altered.', 'wc-serial-numbers' ),
+						'desc'  => __( 'Store serial keys unencrypted in database.', 'wc-serial-numbers' ),
+						'desc_tip' => __( 'If this options is enabled, keys will not be stored in encrypted form.', 'wc-serial-numbers' ),
 						'default' => 'no',
 						'type'  => 'checkbox',
 					],

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -90,7 +90,7 @@ class Settings extends Lib\Settings {
 					[
 						'title' => __( 'Disable encryption', 'wc-serial-numbers' ),
 						'id'    => 'wc_serial_numbers_disable_encryption',
-						'desc'  => __( 'Store serial keys unencrypted in database.', 'wc-serial-numbers' ),
+						'desc'  => __( 'Store serial keys in database as plaintext.', 'wc-serial-numbers' ),
 						'desc_tip' => __( 'If this options is enabled, keys will not be stored in encrypted form.', 'wc-serial-numbers' ),
 						'default' => 'no',
 						'type'  => 'checkbox',

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -65,10 +65,12 @@ class Encryption {
 	 * @return false|string
 	 */
 	public static function maybeEncrypt( $key ) {
-		if ( ! self::isEncrypted( $key ) ) {
+		if(self::isEncrypted( $key ) || 'yes' == wc_serial_numbers_encryption_disabled()) {
+			return $key;
+		} elseif ( ! self::isEncrypted( $key ) ) {
 			return self::encrypt( $key );
 		}
-
+		
 		return $key;
 	}
 

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -67,11 +67,9 @@ class Encryption {
 	public static function maybeEncrypt( $key ) {
 		if(self::isEncrypted( $key ) || 'yes' == wc_serial_numbers_encryption_disabled()) {
 			return $key;
-		} elseif( ! self::isEncrypted( $key ) ) {
-			return self::encrypt( $key );
 		}
-
-		return $key;
+		
+		return self::encrypt( $key );
 	}
 
 	/**

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -68,7 +68,7 @@ class Encryption {
 		if(self::isEncrypted( $key ) || 'yes' == wc_serial_numbers_encryption_disabled()) {
 			return $key;
 		}
-		
+
 		return self::encrypt( $key );
 	}
 

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -67,10 +67,10 @@ class Encryption {
 	public static function maybeEncrypt( $key ) {
 		if(self::isEncrypted( $key ) || 'yes' == wc_serial_numbers_encryption_disabled()) {
 			return $key;
-		} elseif ( ! self::isEncrypted( $key ) ) {
+		} elseif( ! self::isEncrypted( $key ) ) {
 			return self::encrypt( $key );
 		}
-		
+
 		return $key;
 	}
 

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -279,6 +279,7 @@ class Installer {
 		$options               = [
 			'wc_serial_numbers_autocomplete_order'            => $this->update_1_2_0_get_option( 'wsn_auto_complete_order', 'yes', 'wsn_delivery_settings' ),
 			'wc_serial_numbers_reuse_serial_number'           => $this->update_1_2_0_get_option( 'wsn_re_use_serial', 'no', 'wsn_delivery_settings' ),
+			'wc_serial_numbers_disable_encryption'            => 'no',
 			'wc_serial_numbers_disable_software_support'      => 'no',
 			'wc_serial_numbers_manual_delivery'               => 'no',
 			'wc_serial_numbers_hide_serial_number'            => 'yes',

--- a/src/functions.php
+++ b/src/functions.php
@@ -868,6 +868,18 @@ function wcsn_decrypt_key( $key ) {
 }
 
 /**
+ * Check if encryption is disabled (i.e, for real physical product serial numbers)
+ *
+ * @param $product_id
+ *
+ * @return bool
+ * @since 1.x.x
+ */
+function wc_serial_numbers_encryption_disabled() {
+	return 'yes' == get_option( 'wc_serial_numbers_disable_encryption' );
+}
+
+/**
  * Get product stocks
  *
  * @param int  $stock_limit Stock limit.


### PR DESCRIPTION
In some applications, such as tracking of true serial numbers on physical products, database encryption of the numbers provides no benefit and makes troubleshooting and other operations such as db queries more difficult.  This patch provides an option to disable encryption when saving serial numbers (a.k.a. "serial keys").  Existing encrypted keys are still read correctly.

A side benefit is that sub-string searches of the numbers works correctly when they are not encrypted (issue #381 ), and numbers are sorted correctly in the list when that column is chosen.

Warning: Previously saved keys will NOT be de-crypted when the option is changed, and it is possible save un-encrypted numbers that match the existing encrypted version, EVEN IF the "no duplicates" option is enabled.  Therefore, a method for en/de-crypting the entire table when the option is changed should be developed before using this in production code.  Obviously, this is not a concern if starting with an empty table.

For internal use, I use the following function to change the database state after changing the option.  It is VERY inefficient, and takes a minute or so to run with around 1800 keys.  It takes too much time and memory to run synchronously when the option is changed, and running it asynchronously via schedule_event has been unreliable and has potential for race conditions if the option is changed more than once quickly.  Therefore, I run it manually from the shell using `wp eval 'wcsn_resave_keys();'`.  Obviously, this is not a production solution; hopefully the WCSN team knows of a better approach!  (Also, make sure you don't have any keys that start with a `.` character before using this!)

```
function wcsn_resave_keys() {

    $all_keys = WooCommerceSerialNumbers\Models\Key::query(['limit' => -1]);

    foreach($all_keys as $key) {
        $serial_key = $key->get_serial_key();

        if(substr($serial_key, 0, 1) == '.') {  // Clean up any aborted changes from previous run
            $key->set_serial_key(substr($serial_key, 1));
            $key->save();
        } else {

        // Save twice to poison write cache - re-saving with the same number doesn't work
            $key->set_serial_key('.' . $serial_key, 1);
            $key->save();
            $key->set_serial_key($serial_key);
            $key->save();
        }
    }
}
```