### PR TITLE
Fix stock quantity override

### DIFF
--- a/src/Stocks.php
+++ b/src/Stocks.php
@@ -31,7 +31,7 @@ class Stocks {
 	 * @return int
 	 */
 	public static function get_stock_quantity( $quantity, $product ) {
-		if ( ! wcsn_is_product_enabled( $product->get_id() ) ) {
+		if ( wcsn_is_product_enabled( $product->get_id() ) ) {
 			$stocks = wcsn_get_stocks_count();
 			if ( isset( $stocks[ $product->get_id() ] ) ) {
 				$quantity = $stocks[ $product->get_id() ];


### PR DESCRIPTION
Out of stock messages aren't showing up on the product page because the `woocommerce_product_get_stock_quantity` filter logic incorrectly only runs on products where wc-serial-numbers is NOT enabled.