### PR TITLE
Prepare Release v2.1.4

### DIFF
--- a/languages/wc-serial-numbers.pot
+++ b/languages/wc-serial-numbers.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WC Serial Numbers 2.1.3\n"
+"Project-Id-Version: WC Serial Numbers 2.1.4\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/support\n"
-"POT-Creation-Date: 2025-02-11 10:53:46+00:00\n"
+"POT-Creation-Date: 2025-02-25 12:24:23+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -70,38 +70,39 @@ msgstr ""
 msgid "%d orders updated successfully."
 msgstr ""
 
-#: includes/Admin/Orders.php:262
+#: includes/Admin/Orders.php:262 src/Compat.php:74
 msgid "Serial keys sold with this product:"
 msgstr ""
 
 #: includes/Admin/Orders.php:267 src/Admin/ListTables/ActivationsTable.php:178
 #: src/Admin/ListTables/KeysTable.php:349
 #: src/Admin/views/html-api-actions.php:131
-#: src/Admin/views/html-api-validation.php:134 src/Functions/Template.php:42
-#: src/functions.php:1015
+#: src/Admin/views/html-api-validation.php:134 src/Compat.php:79
+#: src/Functions/Template.php:42 src/functions.php:1015
 msgid "Key"
 msgstr ""
 
-#: includes/Admin/Orders.php:271
+#: includes/Admin/Orders.php:271 src/Compat.php:83
 msgid "Expire date"
 msgstr ""
 
 #: includes/Admin/Orders.php:272 src/Admin/ListTables/KeysTable.php:532
-#: src/Functions/Template.php:63 src/functions.php:1036
+#: src/Compat.php:84 src/Functions/Template.php:63 src/functions.php:1036
 msgid "Lifetime"
 msgstr ""
 
 #: includes/Admin/Orders.php:275 src/Admin/views/html-edit-key.php:67
+#: src/Compat.php:87
 msgid "Activation limit"
 msgstr ""
 
-#: includes/Admin/Orders.php:276
+#: includes/Admin/Orders.php:276 src/Compat.php:88
 msgid "Unlimited"
 msgstr ""
 
 #: includes/Admin/Orders.php:279 src/Admin/ListTables/KeysTable.php:360
 #: src/Admin/Menus.php:320 src/Admin/views/html-edit-key.php:92
-#: src/Functions/Template.php:78 src/functions.php:1040
+#: src/Compat.php:91 src/Functions/Template.php:78 src/functions.php:1040
 msgid "Status"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc-serial-numbers",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-serial-numbers",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "GPL v2 or later",
       "devDependencies": {
         "@lodder/time-grunt": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wc-serial-numbers",
   "title": "WC Serial Numbers",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Sell and manage license keys/ serial numbers/ secret keys easily within your WooCommerce store.",
   "homepage": "https://pluginever.com/plugins/woocommerce-serial-numbers-pro/",
   "license": "GPL v2 or later",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: pluginever, manikmist09
 Tags: license, license manager, serial number, serial key, woocommerce
 Tested up to: 6.7
-Stable tag: 2.1.3
+Stable tag: 2.1.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -249,6 +249,9 @@ Yes, you are always welcome to [provide suggestions](https://github.com/pluginev
 10. Order Notification Email with Keys
 
 == Changelog ==
+= 2.1.4 (25th Feb 2025) =
+* Compatibility: Make compatible with the PDF Invoices & Packing Slips for WooCommerce plugin.
+
 = 2.1.2 (23rd Jan 2025) =
 * Fix: Few known issues fixed.
 

--- a/src/Compat.php
+++ b/src/Compat.php
@@ -36,7 +36,7 @@ class Compat {
 	 * @param array     $item Item data.
 	 * @param \WC_Order $order Order object.
 	 *
-	 * @since 1.2.0
+	 * @since 2.1.4
 	 */
 	public static function wpo_wcpdf_after_item_meta( $type, $item, $order ) {
 		$item_id      = isset( $item['item_id'] ) ? $item['item_id'] : 0;

--- a/src/Compat.php
+++ b/src/Compat.php
@@ -18,21 +18,105 @@ class Compat {
 	 * @since 1.0.0
 	 */
 	public function __construct() {
-		add_action( 'wpo_wcpdf_after_order_details', array( __CLASS__, 'wpo_wcpdf_after_order_details' ), 10, 2 );
+		// WooCommerce PDF Invoices & Packing Slips plugin support.
+		add_action( 'wpo_wcpdf_after_item_meta', array( __CLASS__, 'wpo_wcpdf_after_item_meta' ), 10, 3 );
+
+		// WooCommerce PDF Invoices plugin support.
 		add_action( 'pdf_template_table_headings', array( __CLASS__, 'woocommerce_pdf_invoice_support' ), 10, 2 );
+
+		// WooCommerce PDF Invoices, Packing Slips, Delivery Notes & Shipping Labels plugin support.
 		add_action( 'wf_module_generate_template_html', array( __CLASS__, 'wf_module_generate_template_html' ), 10, 4 );
 	}
 
 	/**
 	 * WooCommerce PDF Invoices & Packing Slips plugin support.
+	 * This will display serial numbers in the invoice.
 	 *
 	 * @param string    $type Document type.
+	 * @param array     $item Item data.
 	 * @param \WC_Order $order Order object.
 	 *
 	 * @since 1.2.0
 	 */
-	public static function wpo_wcpdf_after_order_details( $type, $order ) {
-		wc_serial_numbers_get_order_table( $order );
+	public static function wpo_wcpdf_after_item_meta( $type, $item, $order ) {
+		$item_id      = isset( $item['item_id'] ) ? $item['item_id'] : 0;
+		$variation_id = isset( $item['variation_id'] ) ? $item['variation_id'] : 0;
+		$order_id     = $order->get_id();
+		$product_id   = isset( $item['product_id'] ) ? $item['product_id'] : 0;
+
+		if ( empty( $item_id ) || empty( $order_id ) || empty( $product_id ) ) {
+			return;
+		}
+
+		$product = wc_get_product( $product_id );
+
+		if ( ! $product || ! wcsn_is_product_enabled( $product->get_id() ) ) {
+			return;
+		}
+
+		$keys = wcsn_get_keys(
+			apply_filters(
+				'wcsn_order_item_keys_query_args',
+				array(
+					'order_id'   => $order_id,
+					'product_id' => $product->get_id(),
+					'limit'      => - 1,
+				),
+				$item_id,
+				$order_id
+			)
+		);
+
+		if ( empty( $keys ) ) {
+			return;
+		}
+
+		echo '<p style="color: #888;">' . esc_html__( 'Serial keys sold with this product:', 'wc-serial-numbers' ) . '</p>';
+
+		foreach ( $keys as $index => $key ) {
+			$data = array(
+				'key'              => array(
+					'label' => __( 'Key', 'wc-serial-numbers' ),
+					'value' => '<code>' . $key->get_key() . '</code>',
+				),
+				'expire_date'      => array(
+					'label' => __( 'Expire date', 'wc-serial-numbers' ),
+					'value' => $key->get_expire_date() ? $key->get_expire_date() : __( 'Lifetime', 'wc-serial-numbers' ),
+				),
+				'activation_limit' => array(
+					'label' => __( 'Activation limit', 'wc-serial-numbers' ),
+					'value' => $key->get_activation_limit() ? $key->get_activation_limit() : __( 'Unlimited', 'wc-serial-numbers' ),
+				),
+				'status'           => array(
+					'label' => __( 'Status', 'wc-serial-numbers' ),
+					'value' => $key->get_status_label(),
+				),
+			);
+
+			$data = apply_filters( 'wc_serial_numbers_admin_order_item_data', $data, $key, $item, $product, $order_id );
+			if ( empty( $data ) ) {
+				continue;
+			}
+
+			?>
+			<table cellspacing="0" class="display_meta wcsn-admin-order-item-meta" style="margin-bottom: 10px;">
+				<tbody>
+				<tr>
+					<th colspan="2">
+						<?php // translators: %s is the item number. ?>
+						<?php printf( '#%s:', esc_html( $index + 1 ) ); ?>
+					</th>
+				</tr>
+				<?php foreach ( $data as $prop => $field ) : ?>
+					<tr class="<?php echo sanitize_html_class( $prop ); ?>">
+						<th><?php echo esc_html( $field['label'] ); ?>:</th>
+						<td><?php echo wp_kses_post( $field['value'] ); ?></td>
+					</tr>
+				<?php endforeach; ?>
+				</tbody>
+			</table>
+			<?php
+		}
 	}
 
 	/**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -100,6 +100,9 @@ class Plugin extends Lib\Plugin {
 		$this->services['utilities']  = new Utilities\Utilities();
 		$this->services['frontend']   = new Frontend\Frontend();
 
+		// Compatibility.
+		$this->services['compat'] = new Compat();
+
 		if ( wcsn_is_software_support_enabled() ) {
 			$this->services['api'] = new API();
 		}

--- a/wc-serial-numbers.php
+++ b/wc-serial-numbers.php
@@ -3,7 +3,7 @@
  * Plugin Name:          WC Serial Numbers
  * Plugin URI:           https://pluginever.com/plugins/wocommerce-serial-numbers-pro/
  * Description:          Sell and manage license keys/ serial numbers/ secret keys easily within your WooCommerce store.
- * Version:              2.1.3
+ * Version:              2.1.4
  * Requires at least:    5.0
  * Requires PHP:         7.4
  * Author:               PluginEver


### PR DESCRIPTION
This pull request includes several updates and improvements to the `wc-serial-numbers` plugin, primarily focusing on version updates and compatibility enhancements. The most important changes include updating version numbers, adding compatibility with a new plugin, and modifying the `Compat` class to support serial number display in invoices.

### Version Updates:
* Updated `Project-Id-Version` in `languages/wc-serial-numbers.pot` to `2.1.4` and `POT-Creation-Date` to `2025-02-25`.
* Updated `version` in `package.json` to `2.1.4`.
* Updated `Stable tag` in `readme.txt` to `2.1.4`.
* Updated plugin version in `wc-serial-numbers.php` to `2.1.4`.

### Compatibility Enhancements:
* Added compatibility with the "PDF Invoices & Packing Slips for WooCommerce" plugin in `readme.txt`.
* Modified the `Compat` class in `src/Compat.php` to support displaying serial numbers in invoices, including adding the `wpo_wcpdf_after_item_meta` method.
* Initialized the `Compat` service in the `init` method of `src/Plugin.php`.

### Other Changes:
* Updated file references in `languages/wc-serial-numbers.pot` to include `src/Compat.php`.