### PR TITLE
Fix/464

### DIFF
--- a/includes/Compat.php
+++ b/includes/Compat.php
@@ -87,6 +87,14 @@ class Compat {
 					'label' => __( 'Activation limit', 'wc-serial-numbers' ),
 					'value' => $key->get_activation_limit() ? $key->get_activation_limit() : __( 'Unlimited', 'wc-serial-numbers' ),
 				),
+				'activation_count' => array(
+					'label' => __( 'Activation count', 'wc-serial-numbers' ),
+					'value' => $key->get_activation_count(),
+				),
+				'activation_email' => array(
+					'label' => __( 'Activation email', 'wc-serial-numbers' ),
+					'value' => $key->get_customer_email(),
+				),
 				'status'           => array(
 					'label' => __( 'Status', 'wc-serial-numbers' ),
 					'value' => $key->get_status_label(),
@@ -97,6 +105,9 @@ class Compat {
 			if ( empty( $data ) ) {
 				continue;
 			}
+
+			// Filter the data to display.
+			$data = apply_filters( 'wc_serial_numbers_display_key_props', $data, $key );
 
 			?>
 			<table cellspacing="0" class="display_meta wcsn-admin-order-item-meta" style="margin-bottom: 10px;">

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -96,7 +96,6 @@ class Settings extends Lib\Settings {
 						'type'     => 'checkbox',
 						'default'  => 'no',
 					),
-
 					// Enable pdf invoice compatibility.
 					array(
 						'title'    => __( 'WooCommerce PDF Invoices', 'wc-serial-numbers' ),


### PR DESCRIPTION
This pull request includes several updates to the `wc-serial-numbers` plugin to enhance its functionality and ensure better compatibility with other WooCommerce features. The most important changes are listed below:

### Enhancements to Activation Data Display:

* [`includes/Compat.php`](diffhunk://#diff-b15ecce8ec73036a9deec9fbc3e793f3caf12e941e5317a8dbcfe2ebce593ba8R90-R97): Added new fields to display the activation count and activation email in the order item meta. This provides more detailed information about the activation status of serial numbers.

### Codebase Improvements:

* [`includes/Compat.php`](diffhunk://#diff-b15ecce8ec73036a9deec9fbc3e793f3caf12e941e5317a8dbcfe2ebce593ba8R109-R111): Introduced a filter to allow customization of the data displayed in the order item meta. This makes the plugin more flexible and adaptable to different use cases.

### Compatibility Updates:

* [`src/Admin/Settings.php`](diffhunk://#diff-440080228e71b73e795c9dcacdfbf6e4a6df3d3acecfd10bdfdf086ee6eaa9ceL99): Removed an unnecessary blank line in the settings array to improve code readability and maintain consistency.