### PR TITLE
Prepare release v2.1.6

### DIFF
--- a/languages/wc-serial-numbers.pot
+++ b/languages/wc-serial-numbers.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WC Serial Numbers 2.1.5\n"
+"Project-Id-Version: WC Serial Numbers 2.1.6\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/support\n"
-"POT-Creation-Date: 2025-03-18 07:31:50+00:00\n"
+"POT-Creation-Date: 2025-03-18 10:27:13+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -102,7 +102,7 @@ msgstr ""
 msgid "Unlimited"
 msgstr ""
 
-#: includes/Admin/Orders.php:279 includes/Compat.php:91
+#: includes/Admin/Orders.php:279 includes/Compat.php:99
 #: src/Admin/ListTables/KeysTable.php:360 src/Admin/Menus.php:320
 #: src/Admin/views/html-edit-key.php:92 src/Functions/Template.php:78
 #: src/functions.php:1040
@@ -195,6 +195,14 @@ msgstr ""
 msgid "%1$s (#%2$s - %3$s)"
 msgstr ""
 
+#: includes/Compat.php:91
+msgid "Activation count"
+msgstr ""
+
+#: includes/Compat.php:95
+msgid "Activation email"
+msgstr ""
+
 #: lib/Lib/Model.php:424
 #. translators: %s: database error message.
 msgid "Could not insert item into the database error %s"
@@ -208,7 +216,7 @@ msgstr ""
 msgid "Go Pro"
 msgstr ""
 
-#: lib/Lib/Plugin.php:655 src/Admin/Settings.php:213
+#: lib/Lib/Plugin.php:655 src/Admin/Settings.php:212
 msgid "Documentation"
 msgstr ""
 
@@ -698,18 +706,18 @@ msgstr ""
 msgid ""
 "Enable stock management for key-enabled products. This works only if you "
 "select \"Manually Added\" as the key source and enable stock management for "
-"the product."
+"the product. Variable product is not supported."
 msgstr ""
 
-#: src/Admin/Settings.php:102
+#: src/Admin/Settings.php:101
 msgid "WooCommerce PDF Invoices"
 msgstr ""
 
-#: src/Admin/Settings.php:104
+#: src/Admin/Settings.php:103
 msgid "Enable WooCommerce PDF Invoices."
 msgstr ""
 
-#: src/Admin/Settings.php:107
+#: src/Admin/Settings.php:106
 #. translators: %s: documentation link
 msgid ""
 "If you enable this option, the plugin will be compatible with WooCommerce "
@@ -718,103 +726,103 @@ msgid ""
 "for more details."
 msgstr ""
 
-#: src/Admin/Settings.php:118
+#: src/Admin/Settings.php:117
 msgid "Stock Notification"
 msgstr ""
 
-#: src/Admin/Settings.php:120
+#: src/Admin/Settings.php:119
 msgid "These options determine the operation of the key's stock notification."
 msgstr ""
 
-#: src/Admin/Settings.php:124
+#: src/Admin/Settings.php:123
 msgid "Stock notification email"
 msgstr ""
 
-#: src/Admin/Settings.php:126
+#: src/Admin/Settings.php:125
 msgid "Sends notification emails when key stock is low."
 msgstr ""
 
-#: src/Admin/Settings.php:132
+#: src/Admin/Settings.php:131
 msgid "Stock threshold"
 msgstr ""
 
-#: src/Admin/Settings.php:134
+#: src/Admin/Settings.php:133
 msgid ""
 "An email notification will be sent when the key stock falls below the "
 "specified number."
 msgstr ""
 
-#: src/Admin/Settings.php:139
+#: src/Admin/Settings.php:138
 msgid "Notification recipient email"
 msgstr ""
 
-#: src/Admin/Settings.php:141
+#: src/Admin/Settings.php:140
 msgid "The email address which will be used to send email notifications."
 msgstr ""
 
-#: src/Admin/Settings.php:175
+#: src/Admin/Settings.php:174
 msgid "Create and assign keys for WooCommerce variable products."
 msgstr ""
 
-#: src/Admin/Settings.php:176
+#: src/Admin/Settings.php:175
 msgid "Generate bulk keys with your custom key generator rule."
 msgstr ""
 
-#: src/Admin/Settings.php:177
+#: src/Admin/Settings.php:176
 msgid "Random & sequential key order for the generator rules."
 msgstr ""
 
-#: src/Admin/Settings.php:178
+#: src/Admin/Settings.php:177
 msgid "Automatic key generator to auto-create & assign keys with orders."
 msgstr ""
 
-#: src/Admin/Settings.php:179
+#: src/Admin/Settings.php:178
 msgid "License key management option from the order page with required actions."
 msgstr ""
 
-#: src/Admin/Settings.php:180
+#: src/Admin/Settings.php:179
 msgid "Support for bulk import/export of keys from/to CSV."
 msgstr ""
 
-#: src/Admin/Settings.php:181
+#: src/Admin/Settings.php:180
 msgid "Send keys via SMS with Twilio."
 msgstr ""
 
-#: src/Admin/Settings.php:182
+#: src/Admin/Settings.php:181
 msgid "Option to sell keys even if there are no available keys in the stock."
 msgstr ""
 
-#: src/Admin/Settings.php:183
+#: src/Admin/Settings.php:182
 msgid "Custom deliverable quantity to deliver multiple keys with a single product."
 msgstr ""
 
-#: src/Admin/Settings.php:184
+#: src/Admin/Settings.php:183
 msgid ""
 "Manual delivery option to manually deliver license keys instead of "
 "automatic."
 msgstr ""
 
-#: src/Admin/Settings.php:185
+#: src/Admin/Settings.php:184
 msgid ""
 "Email template to easily and quickly customize the order confirmation & low "
 "stock alert email."
 msgstr ""
 
-#: src/Admin/Settings.php:186
+#: src/Admin/Settings.php:185
 msgid "Many more ..."
 msgstr ""
 
-#: src/Admin/Settings.php:190
+#: src/Admin/Settings.php:189
 msgid "Want More?"
 msgstr ""
 
-#: src/Admin/Settings.php:191
+#: src/Admin/Settings.php:190
 msgid ""
 "This plugin offers a premium version which comes with the following "
 "features:"
 msgstr ""
 
-#: src/Admin/Settings.php:197
+#: src/Admin/Settings.php:196
 msgid "Upgrade to PRO"
 msgstr ""
 
@@ -1446,7 +1454,7 @@ msgid "WC Serial Numbers"
 msgstr ""
 
 #. Plugin URI of the plugin/theme
-msgid "https://pluginever.com/plugins/wocommerce-serial-numbers-pro/"
+msgid "https://pluginever.com/plugins/woocommerce-serial-numbers-pro/"
 msgstr ""
 
 #. Description of the plugin/theme

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc-serial-numbers",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-serial-numbers",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "GPL v2 or later",
       "devDependencies": {
         "@lodder/time-grunt": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wc-serial-numbers",
   "title": "WC Serial Numbers",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Sell and manage license keys/ serial numbers/ secret keys easily within your WooCommerce store.",
   "homepage": "https://pluginever.com/plugins/woocommerce-serial-numbers-pro/",
   "license": "GPL v2 or later",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: pluginever, manikmist09
 Tags: license, license manager, serial number, serial key, woocommerce
 Tested up to: 6.7
-Stable tag: 2.1.5
+Stable tag: 2.1.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -249,6 +249,10 @@ Yes, you are always welcome to [provide suggestions](https://github.com/pluginev
 10. Order Notification Email with Keys
 
 == Changelog ==
+= 2.1.6 (18th Mar 2025) =
+* Fix: Few known issues fixed.
+* New: Add new feature to Manage Stocks.
+
 = 2.1.5 (4th Mar 2025) =
 * New: Add new settings for managing the WooCommerce PDF Invoices & Packing Slips plugin.
 * Fix: Few known issues fixed.

--- a/wc-serial-numbers.php
+++ b/wc-serial-numbers.php
@@ -3,7 +3,7 @@
  * Plugin Name:          WC Serial Numbers
  * Plugin URI:           https://pluginever.com/plugins/woocommerce-serial-numbers-pro/
  * Description:          Sell and manage license keys/ serial numbers/ secret keys easily within your WooCommerce store.
- * Version:              2.1.5
+ * Version:              2.1.6
  * Requires at least:    5.0
  * Requires PHP:         7.4
  * Author:               PluginEver


### PR DESCRIPTION
This pull request includes several updates to the `WC Serial Numbers` plugin, primarily focusing on version updates and minor text adjustments. The most important changes are listed below:

Version updates:

* Updated the version number from 2.1.5 to 2.1.6 in `languages/wc-serial-numbers.pot`, `package.json`, `readme.txt`, and `wc-serial-numbers.php`. [[1]](diffhunk://#diff-2b13502d9fa2ba7b54f1a03bfbd072532c6fb9372859c867a57c38ec67801d38L5-R7) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L5-R5) [[4]](diffhunk://#diff-0554005800d2e069310a1284f38b55bf7468023c89a7299d79aeb519755bbafcL6-R6)

Text adjustments:

* Updated the plugin URI in `languages/wc-serial-numbers.pot` to correct a typo in the URL.
* Added new message identifiers and adjusted existing ones in `languages/wc-serial-numbers.pot` to reflect recent changes in the codebase. [[1]](diffhunk://#diff-2b13502d9fa2ba7b54f1a03bfbd072532c6fb9372859c867a57c38ec67801d38L105-R105) [[2]](diffhunk://#diff-2b13502d9fa2ba7b54f1a03bfbd072532c6fb9372859c867a57c38ec67801d38R198-R205) [[3]](diffhunk://#diff-2b13502d9fa2ba7b54f1a03bfbd072532c6fb9372859c867a57c38ec67801d38L211-R219) [[4]](diffhunk://#diff-2b13502d9fa2ba7b54f1a03bfbd072532c6fb9372859c867a57c38ec67801d38L701-R720) [[5]](diffhunk://#diff-2b13502d9fa2ba7b54f1a03bfbd072532c6fb9372859c867a57c38ec67801d38L721-R825)
* Updated the changelog in `readme.txt` to include the latest version and its changes.