### PR TITLE
Prepare Release v2.1.7

### DIFF
--- a/languages/wc-serial-numbers.pot
+++ b/languages/wc-serial-numbers.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WC Serial Numbers 2.1.6\n"
+"Project-Id-Version: WC Serial Numbers 2.1.7\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/support\n"
-"POT-Creation-Date: 2025-03-18 10:27:13+00:00\n"
+"POT-Creation-Date: 2025-04-08 04:28:03+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc-serial-numbers",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-serial-numbers",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "GPL v2 or later",
       "devDependencies": {
         "@lodder/time-grunt": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wc-serial-numbers",
   "title": "WC Serial Numbers",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Sell and manage license keys/ serial numbers/ secret keys easily within your WooCommerce store.",
   "homepage": "https://pluginever.com/plugins/woocommerce-serial-numbers-pro/",
   "license": "GPL v2 or later",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: pluginever, manikmist09
 Tags: license, license manager, serial number, serial key, woocommerce
 Tested up to: 6.7
-Stable tag: 2.1.6
+Stable tag: 2.1.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/wc-serial-numbers.php
+++ b/wc-serial-numbers.php
@@ -3,7 +3,7 @@
  * Plugin Name:          WC Serial Numbers
  * Plugin URI:           https://pluginever.com/plugins/woocommerce-serial-numbers-pro/
  * Description:          Sell and manage license keys/ serial numbers/ secret keys easily within your WooCommerce store.
- * Version:              2.1.6
+ * Version:              2.1.7
  * Requires at least:    5.0
  * Requires PHP:         7.4
  * Author:               PluginEver


### PR DESCRIPTION
This pull request includes a version update for the WC Serial Numbers plugin from 2.1.6 to 2.1.7. The changes span across multiple files to reflect the new version number.

Version update:

* [`languages/wc-serial-numbers.pot`](diffhunk://#diff-2b13502d9fa2ba7b54f1a03bfbd072532c6fb9372859c867a57c38ec67801d38L5-R7): Updated `Project-Id-Version` and `POT-Creation-Date` to reflect the new version 2.1.7.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the `version` field to 2.1.7.
* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L5-R5): Updated the `Stable tag` to 2.1.7.
* [`wc-serial-numbers.php`](diffhunk://#diff-0554005800d2e069310a1284f38b55bf7468023c89a7299d79aeb519755bbafcL6-R6): Updated the `Version` field in the plugin header to 2.1.7.

and Prepare Release v2.1.7