### PR TITLE
Prepare Release v2.2.0

### DIFF
--- a/languages/wc-serial-numbers.pot
+++ b/languages/wc-serial-numbers.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WC Serial Numbers 2.1.9\n"
+"Project-Id-Version: WC Serial Numbers 2.2.0\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/support\n"
-"POT-Creation-Date: 2025-05-29 06:22:13+00:00\n"
+"POT-Creation-Date: 2025-06-19 09:37:59+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc-serial-numbers",
-  "version": "2.1.9",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-serial-numbers",
-      "version": "2.1.9",
+      "version": "2.2.0",
       "license": "GPL v2 or later",
       "devDependencies": {
         "@lodder/time-grunt": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wc-serial-numbers",
   "title": "WC Serial Numbers",
-  "version": "2.1.9",
+  "version": "2.2.0",
   "description": "Sell and manage license keys/ serial numbers/ secret keys easily within your WooCommerce store.",
   "homepage": "https://pluginever.com/plugins/woocommerce-serial-numbers-pro/",
   "license": "GPL v2 or later",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: pluginever, manikmist09
 Tags: license, license manager, serial number, serial key, woocommerce
 Tested up to: 6.8
-Stable tag: 2.1.9
+Stable tag: 2.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -249,6 +249,10 @@ Yes, you are always welcome to [provide suggestions](https://github.com/pluginev
 10. Order Notification Email with Keys
 
 == Changelog ==
+= 2.2.0 (19 Jun 2025) =
+* Fix: Framework Model enhanced to allow filter the keys sql query.
+* Compatibility: Make compatible with the latest version of WooCommerce and WordPress.
+
 = 2.1.9 (29 May 2025) =
 * Fix: Few known issues fixed.
 

--- a/wc-serial-numbers.php
+++ b/wc-serial-numbers.php
@@ -3,7 +3,7 @@
  * Plugin Name:          WC Serial Numbers
  * Plugin URI:           https://pluginever.com/plugins/woocommerce-serial-numbers-pro/
  * Description:          Sell and manage license keys/ serial numbers/ secret keys easily within your WooCommerce store.
- * Version:              2.1.9
+ * Version:              2.2.0
  * Requires at least:    5.0
  * Requires PHP:         7.4
  * Author:               PluginEver
@@ -14,7 +14,7 @@
  * Domain Path:          /languages
  * Tested up to:         6.8
  * WC requires at least: 3.0.0
- * WC tested up to:      9.8
+ * WC tested up to:      9.9
  * Requires Plugins:     woocommerce
  *
  * @package WooCommerceSerialNumbers


### PR DESCRIPTION
This pull request updates the WC Serial Numbers plugin to version 2.2.0, with changes to versioning, compatibility, and functionality enhancements. The most important updates include version bumps across various files, improved compatibility with the latest versions of WooCommerce and WordPress, and enhancements to the framework model.

### Version Updates:
* Updated the plugin version from `2.1.9` to `2.2.0` in `package.json`, `wc-serial-numbers.php`, `readme.txt`, and `languages/wc-serial-numbers.pot`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-0554005800d2e069310a1284f38b55bf7468023c89a7299d79aeb519755bbafcL6-R6) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L5-R5) [[4]](diffhunk://#diff-2b13502d9fa2ba7b54f1a03bfbd072532c6fb9372859c867a57c38ec67801d38L5-R7)

### Compatibility Enhancements:
* Marked the plugin as compatible with WooCommerce version `9.9` and WordPress version `6.8` in `wc-serial-numbers.php` and `readme.txt`. [[1]](diffhunk://#diff-0554005800d2e069310a1284f38b55bf7468023c89a7299d79aeb519755bbafcL17-R17) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R252-R255)

### Functional Improvements:
* Enhanced the framework model to allow filtering of the keys SQL query, as noted in the changelog.
Prepare Release v2.2.0