### PR TITLE
Fix #489

### DIFF
--- a/languages/wc-serial-numbers.pot
+++ b/languages/wc-serial-numbers.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WC Serial Numbers 2.2.5\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/support\n"
-"POT-Creation-Date: 2025-10-21 11:44:22+00:00\n"
+"POT-Creation-Date: 2025-10-23 12:31:54+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -114,7 +114,7 @@ msgstr ""
 msgid "View Details"
 msgstr ""
 
-#: includes/Admin/Products.php:92 src/Admin/Admin.php:143
+#: includes/Admin/Products.php:92 src/Admin/Admin.php:148
 #: src/Admin/Menus.php:54 src/Admin/Menus.php:88 src/Admin/Menus.php:89
 #: src/Admin/Menus.php:433 src/Functions/Template.php:226
 msgid "Serial Numbers"
@@ -268,42 +268,42 @@ msgstr ""
 msgid "Missing data."
 msgstr ""
 
-#: src/Admin/Admin.php:67
+#: src/Admin/Admin.php:72
 msgid "Search by product"
 msgstr ""
 
-#: src/Admin/Admin.php:68
+#: src/Admin/Admin.php:73
 msgid "Search by order"
 msgstr ""
 
-#: src/Admin/Admin.php:69
+#: src/Admin/Admin.php:74
 msgid "Search by customer"
 msgstr ""
 
-#: src/Admin/Admin.php:70
+#: src/Admin/Admin.php:75
 msgid "Show"
 msgstr ""
 
-#: src/Admin/Admin.php:71
+#: src/Admin/Admin.php:76
 msgid "Hide"
 msgstr ""
 
-#: src/Admin/Admin.php:72 src/Frontend/Frontend.php:56
+#: src/Admin/Admin.php:77 src/Frontend/Frontend.php:56
 msgid "Copied"
 msgstr ""
 
-#: src/Admin/Admin.php:110
+#: src/Admin/Admin.php:115
 #. translators: 1: Plugin name 2: WordPress
 msgid ""
 "Thank you for using %1$s! Share your appreciation with a five-star review "
 "%2$s."
 msgstr ""
 
-#: src/Admin/Admin.php:112
+#: src/Admin/Admin.php:117
 msgid "Thanks :)"
 msgstr ""
 
-#: src/Admin/Admin.php:130
+#: src/Admin/Admin.php:135
 #. translators: 1: Plugin version
 msgid "Version %s"
 msgstr ""

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -53,12 +53,17 @@ class Admin {
 		if ( ! in_array( $hook, self::get_screen_ids(), true ) ) {
 			return;
 		}
+
+		// Determine which select2 to use. WooCommerce 3.6+ uses its own select2 but the latest WooCommerce 10.3+ deprecated it and added wc-select2 style/js handle.
+		$which_select2_style  = wp_style_is( 'wc-select2', 'registered' ) ? 'wc-select2' : 'select2';
+		$which_select2_script = wp_script_is( 'wc-select2', 'registered' ) ? 'wc-select2' : 'select2';
+
 		wp_enqueue_style( 'jquery-ui-style' );
-		wp_enqueue_style( 'wc-select2' );
+		wp_enqueue_style( $which_select2_style );
 		wp_enqueue_script( 'jquery-ui-datepicker' );
 
 		WCSN()->enqueue_style( 'wc-serial-numbers-admin', 'css/admin-style.css' );
-		WCSN()->enqueue_script( 'wc-serial-numbers-admin', 'js/admin-script.js', array( 'jquery', 'jquery-ui-datepicker', 'wc-select2', 'wp-util' ) );
+		WCSN()->enqueue_script( 'wc-serial-numbers-admin', 'js/admin-script.js', array( 'jquery', 'jquery-ui-datepicker', $which_select2_script, 'wp-util' ) );
 		wp_localize_script(
 			'wc-serial-numbers-admin',
 			'wc_serial_numbers_vars',


### PR DESCRIPTION
Fix #489

This pull request updates the script and style dependencies in the admin area to use the WooCommerce-specific Select2 assets instead of the generic ones. This ensures better compatibility with WooCommerce styling and scripts.

Dependency updates:

* Changed the enqueued style from `select2` to `wc-select2` in the `enqueue_scripts` method in `src/Admin/Admin.php`.
* Updated the script dependencies for `wc-serial-numbers-admin` to use `wc-select2` instead of `select2` in `src/Admin/Admin.php`.