### PR TITLE
Prepare Release v2.3.2

### DIFF
--- a/languages/wc-serial-numbers.pot
+++ b/languages/wc-serial-numbers.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Serial Numbers 2.3.1\n"
+"Project-Id-Version: Serial Numbers 2.3.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wc-serial-numbers\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-01-14T04:41:45+00:00\n"
+"POT-Creation-Date: 2026-01-27T12:09:18+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: wc-serial-numbers\n"
@@ -1413,7 +1413,7 @@ msgid "There are few  products stock running low, please add serial numbers for 
 msgstr ""
 
 #. translators: %s: plugin url.
-#: templates/email-stock-notification.php:37
+#: templates/email-stock-notification.php:42
 #, php-format
 msgid "The email is sent by <a href=\"%s\" target=\"_blank\">Serial Numbers for WooCommerce</a>"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
 	"name": "wc-serial-numbers",
-	"version": "2.3.1",
+	"version": "2.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wc-serial-numbers",
-			"version": "2.3.1",
+			"version": "2.3.2",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@byteever/scripts": "^3.0.4",
 				"@wordpress/browserslist-config": "^6.37.0",
 				"@wordpress/prettier-config": "^4.37.0",
-				"@wordpress/scripts": "^31.2.0"
+				"@wordpress/scripts": "^31.3.0"
 			},
 			"engines": {
 				"node": ">=20.11.1"
@@ -2067,26 +2067,26 @@
 			}
 		},
 		"node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.0.tgz",
-			"integrity": "sha512-KT01GjzV6AQD5+IYrcpoYLkCu1Jod3nau1Z7EsEuViO3TZGRacSbO9MfHmbJ1WaOXFtWLxPVj169cn2WNKPkIg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+			"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hashery": "^1.2.0",
-				"hookified": "^1.13.0"
+				"hashery": "^1.4.0",
+				"hookified": "^1.15.0"
 			},
 			"engines": {
 				"node": ">= 18"
 			},
 			"peerDependencies": {
-				"keyv": "^5.5.4"
+				"keyv": "^5.6.0"
 			}
 		},
 		"node_modules/@cacheable/memory/node_modules/keyv": {
-			"version": "5.5.5",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
-			"integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2105,9 +2105,9 @@
 			}
 		},
 		"node_modules/@cacheable/utils/node_modules/keyv": {
-			"version": "5.5.5",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
-			"integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2210,9 +2210,9 @@
 			}
 		},
 		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.0.23",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.23.tgz",
-			"integrity": "sha512-YEmgyklR6l/oKUltidNVYdjSmLSW88vMsKx0pmiS3r71s8ZZRpd8A0Yf0U+6p/RzElmMnPBv27hNWjDQMSZRtQ==",
+			"version": "1.0.26",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
+			"integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2224,10 +2224,7 @@
 					"url": "https://opencollective.com/csstools"
 				}
 			],
-			"license": "MIT-0",
-			"engines": {
-				"node": ">=18"
-			}
+			"license": "MIT-0"
 		},
 		"node_modules/@csstools/css-tokenizer": {
 			"version": "3.0.4",
@@ -3894,9 +3891,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.38.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
-			"integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
+			"integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -4254,14 +4251,14 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.57.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-			"integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+			"version": "1.58.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
+			"integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.57.0"
+				"playwright": "1.58.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -5098,12 +5095,13 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.2.0.tgz",
-			"integrity": "sha512-bm6EG6/pCpkxDf/0gDNDdtDILMOHgaQBVOJGdwsqClnxA3xL6jtMv76rLBc006RVMWbmaf0xbmom4Z/5o2nRkQ==",
+			"version": "20.19.30",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
+			"integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.13.0"
+				"undici-types": "~6.21.0"
 			}
 		},
 		"node_modules/@types/node-forge": {
@@ -5150,6 +5148,13 @@
 				"@types/pg": "*"
 			}
 		},
+		"node_modules/@types/prop-types": {
+			"version": "15.7.15",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/qs": {
 			"version": "6.9.15",
 			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
@@ -5161,6 +5166,27 @@
 			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
 			"integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
 			"dev": true
+		},
+		"node_modules/@types/react": {
+			"version": "18.3.27",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
+			"integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/prop-types": "*",
+				"csstype": "^3.2.2"
+			}
+		},
+		"node_modules/@types/react-dom": {
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
+			}
 		},
 		"node_modules/@types/retry": {
 			"version": "0.12.0",
@@ -6014,9 +6040,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.37.0.tgz",
-			"integrity": "sha512-tPLa2YFAau+gT2zKovRK5DRiJchsKgNFiuElIWeKYkLytkyws9fQAgjF/AkDFFxRMdDocNfCscpKWhp79+tIFA==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.38.0.tgz",
+			"integrity": "sha512-5DxPlGcB2EDpZjYI9FD1rOcYRaYuPr9EXNhDsiX+Mbxgj6ZZvWeJAT+E/8YlAOO969skUjxk/BIScQRSE99HbA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -6026,8 +6052,8 @@
 				"@babel/plugin-transform-runtime": "7.25.7",
 				"@babel/preset-env": "7.25.7",
 				"@babel/preset-typescript": "7.25.7",
-				"@wordpress/browserslist-config": "^6.37.0",
-				"@wordpress/warning": "^3.37.0",
+				"@wordpress/browserslist-config": "^6.38.0",
+				"@wordpress/warning": "^3.38.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
@@ -6054,9 +6080,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.13.0.tgz",
-			"integrity": "sha512-+APLd5GqzzJ/atVVs3LGPcCRRy8mVfVQi1QY+cseNAQbRe4LvsDarLbzkblWEwuksxgUGmVGDC3fDNxrwszJ2A==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.14.0.tgz",
+			"integrity": "sha512-0NoWb5+gVGUMZ8RiAE4g4dJ08ZdSMrWdnt/fp//BclezTdOLepZPzZ9O6nDWLVdlNgnYLhPwK/t5jxOow5WRoA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6065,9 +6091,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.37.0.tgz",
-			"integrity": "sha512-L//FRak9bo+sDLAignC4QkhITHgeFVlL0C4lWI/AM+AIHKGrHT4LOdwwNpYWMkkztW9rxHRptGkF/JDxuCakxQ==",
+			"version": "6.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.38.0.tgz",
+			"integrity": "sha512-cLm8mg7jHdajpkuC0ohjy1/DWB7X/mrW8N5spA0ukKfj+CbJi7+PVFeeEPCjDLEybnlqrVCJ8VaLaxde+xU3UA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6076,9 +6102,9 @@
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.37.0.tgz",
-			"integrity": "sha512-N9DTLr07AYV9vo/kFVSKYp/+wg2wBHL4ekDldwx2rGNtOHjoSi1oo+iBmStSaKMRtCQX2Xq8xVFH04+53T0yXA==",
+			"version": "6.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.38.0.tgz",
+			"integrity": "sha512-N/wjZ7Ne5D3ASXgEqKhLeAsbYPUtmSAXmyd31dMChIP6HnN9kuN+iyrxNR3COg2VoW7K9VAhwTzEEGQrOQv/rw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -6100,9 +6126,9 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.37.0.tgz",
-			"integrity": "sha512-H77He9+sPNchzbEeFk2YSuYW5JNk3oHnlXJ1EVPUHpIZTr6gM80AGBuxP/W4WtWdLn0A5/TxCmTAxsN1M8YVvQ==",
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.38.0.tgz",
+			"integrity": "sha512-/3Qo6/N5BtCbQJJShy3pY5xr68OkMctouYcz1mvL8Q8tMO1fdiZTlJvU9bSMwdM1G1NEbE8pa/9q2F1Va/2S2A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -6117,21 +6143,64 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": ">=1"
+				"@playwright/test": ">=1",
+				"@types/node": "^20.17.10"
+			}
+		},
+		"node_modules/@wordpress/element": {
+			"version": "6.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.38.0.tgz",
+			"integrity": "sha512-4N9xtuE2TIvaZ037fQREKrBw4TTt90PWswAfNFvxUVu5vdp91PLuR6rmeO0ohKg2CJLzozQLEKZF+6VuSaYowQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.38.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/element/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/escape-html": {
+			"version": "3.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.38.0.tgz",
+			"integrity": "sha512-LItqIdFnn/JAVEzTtvDZGJfsdmzeIE4ryMjovHkJhRElzcQWKHuq806DMprL40NcvJbdn0YfJZSv+aeP+9Ah3g==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
-			"version": "23.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-23.0.0.tgz",
-			"integrity": "sha512-fdgBWc7jC0JKi8j16lt51F3Sp02n7emSU3af5UFnQ5feXyJSO3mGcVJzZDpehL3ts/Clhu3II+CYOlUeek4H8g==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-24.0.0.tgz",
+			"integrity": "sha512-FXf427hQNXymMxk+qvzejXLEnnn64aGNHBEDMUYpt4MJx98+Upo2uYG0JGWm5y/Aqm+rBlGgdyNsQjjSB+Q6pQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/eslint-parser": "7.25.7",
 				"@typescript-eslint/eslint-plugin": "^6.4.1",
 				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^8.37.0",
-				"@wordpress/prettier-config": "^4.37.0",
+				"@wordpress/babel-preset-default": "^8.38.0",
+				"@wordpress/prettier-config": "^4.38.0",
+				"@wordpress/theme": "^0.5.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-import-resolver-typescript": "^4.4.4",
@@ -6183,13 +6252,14 @@
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "8.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.37.0.tgz",
-			"integrity": "sha512-RTNy0qg1sQLRunqsWjCAR8Nw2RZ62DSIaf09J6xzmuYdFjdvsmeQWs0OSs9e6mVQftxqDgJ/V4NQ1ctLxZM06w==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.38.0.tgz",
+			"integrity": "sha512-pRvWbxr/PHs2IsjsVvb9kBgqcxOcPnTN/baOmmEJFHVtOa5hp/ze6zbz/c18RCmrxWt5doRwHpfH84M/yivo2A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"jest-matcher-utils": "^29.6.2"
+				"jest-matcher-utils": "^29.6.2",
+				"jest-mock": "^29.6.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -6200,13 +6270,13 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "12.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.37.0.tgz",
-			"integrity": "sha512-AaT02lS2a/FnD/arYSSc1TkbIlLd1zXY40YqGtpYz1/MqJKoje6th/RZGOMQKC1pyXt5KKBzSFMD4Av39CxThw==",
+			"version": "12.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.38.0.tgz",
+			"integrity": "sha512-rAEYTMbpmfhYA5p3HmkhsTXM3rHq+4mdmt8xS5izXn5SzZdsHs+oa1Ej9COMi6xThpMN5i0+N+vz3HDzAMLCsg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/jest-console": "^8.37.0",
+				"@wordpress/jest-console": "^8.38.0",
 				"babel-jest": "29.7.0"
 			},
 			"engines": {
@@ -6219,9 +6289,9 @@
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "5.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.37.0.tgz",
-			"integrity": "sha512-Ond/mR+fw+8JMlcMmj1MBjVgQKD7GVYlL3Ww1n1/yBpRS9OP+UECF4vES3rdEqvL8TU+O/cvoWFpNY2DWO4P8w==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.38.0.tgz",
+			"integrity": "sha512-/8oarSArKiN2ZUTCexn27YQLPXpxmNAYQEzgubmALtR5wGWnMwpCw9bt/+/cG6t6o1YaAN8ZOO3gattQYssYrA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6233,13 +6303,13 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "5.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.37.0.tgz",
-			"integrity": "sha512-6+/aFPjr3AhmiBQEZs/huG3pkHPUHwwqwS8IIUqwDFuXnX3RkqRJvIoLdfDyR04QaFamyk1IoRv01zU0pZB8YA==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.38.0.tgz",
+			"integrity": "sha512-I8QFM8pPv04VTvakhIqRL5CU8s6Irf7onixBjXD95+ae3kmVJY548mp7cBU5MV9n92IZbGbwLjhaOIegS3QxfQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/base-styles": "^6.13.0",
+				"@wordpress/base-styles": "^6.14.0",
 				"autoprefixer": "^10.4.20",
 				"postcss-import": "^16.1.1"
 			},
@@ -6252,9 +6322,9 @@
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
-			"version": "4.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.37.0.tgz",
-			"integrity": "sha512-5l+5q07DXpoMhGWxVjJqb60RFyspaD7twCnnVWzqfFNUfKWptytMj3KYV3oO9+4ONWehsEzRF9zl3ai+S6ztvg==",
+			"version": "4.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.38.0.tgz",
+			"integrity": "sha512-kWGpmmkIvvObtteeOBkZM3GiTOL8tBkccBJwIWV7kBIC71HrBERnvQZKga84QW5thdt+S0ccjBZk41saEGXavw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6265,26 +6335,37 @@
 				"prettier": ">=3"
 			}
 		},
+		"node_modules/@wordpress/private-apis": {
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.38.0.tgz",
+			"integrity": "sha512-6Hj9x3xJb64Xu/p2M4XA9fGeY2omTly2bb+Kayaa55eEZi6iXlcIhvv7UAdKhJ2PF9hfuENccgqhG7OrvaEEJg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/scripts": {
-			"version": "31.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-31.2.0.tgz",
-			"integrity": "sha512-0BKF/aWGX2MegnsgxNkoKQCIlZzvzc/w9noC0hCsNCQqgTolP+idtr8sBA3J2E5gP3ieGk4DCr9CbAtLjkP23g==",
+			"version": "31.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-31.3.0.tgz",
+			"integrity": "sha512-gZiw7y3/tNbzxcW4IXBszyTzP7KkZivDGAvL01sJ1bcVTTuD4LyQ4MXhesCUYEYXPkSRNQh1Q4oAXk1FH3DlSQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "7.25.7",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.37.0",
-				"@wordpress/browserslist-config": "^6.37.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.37.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.37.0",
-				"@wordpress/eslint-plugin": "^23.0.0",
-				"@wordpress/jest-preset-default": "^12.37.0",
-				"@wordpress/npm-package-json-lint-config": "^5.37.0",
-				"@wordpress/postcss-plugins-preset": "^5.37.0",
-				"@wordpress/prettier-config": "^4.37.0",
-				"@wordpress/stylelint-config": "^23.29.0",
+				"@wordpress/babel-preset-default": "^8.38.0",
+				"@wordpress/browserslist-config": "^6.38.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^6.38.0",
+				"@wordpress/e2e-test-utils-playwright": "^1.38.0",
+				"@wordpress/eslint-plugin": "^24.0.0",
+				"@wordpress/jest-preset-default": "^12.38.0",
+				"@wordpress/npm-package-json-lint-config": "^5.38.0",
+				"@wordpress/postcss-plugins-preset": "^5.38.0",
+				"@wordpress/prettier-config": "^4.38.0",
+				"@wordpress/stylelint-config": "^23.30.0",
 				"adm-zip": "^0.5.9",
 				"babel-jest": "29.7.0",
 				"babel-loader": "9.2.1",
@@ -6297,7 +6378,7 @@
 				"cssnano": "^6.0.1",
 				"cwd": "^0.10.0",
 				"dir-glob": "^3.0.1",
-				"eslint": "^8.3.0",
+				"eslint": "^8.57.1",
 				"expect-puppeteer": "^4.4.0",
 				"fast-glob": "^3.2.7",
 				"filenamify": "^4.2.0",
@@ -6420,13 +6501,14 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "23.29.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.29.0.tgz",
-			"integrity": "sha512-TTT2oc9Fw2rdnCs4bzI2EHRXgODT3YggjcewqxbBcioPsiAOff9E9gp6NZhe2VlZjVsDcwabUs6m4RIgbBSKaQ==",
+			"version": "23.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.30.0.tgz",
+			"integrity": "sha512-35s8w52ZxTVkvllBSCMbV2cFLQjHd+8FzROUIBW0OaUlZum3bQXnz2I3Q71e6fG2/jXvXVrHRh45P2oIhWnKPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@stylistic/stylelint-plugin": "^3.0.1",
+				"@wordpress/theme": "^0.5.0",
 				"stylelint-config-recommended": "^14.0.1",
 				"stylelint-config-recommended-scss": "^14.1.0"
 			},
@@ -6439,10 +6521,37 @@
 				"stylelint-scss": "^6.4.0"
 			}
 		},
+		"node_modules/@wordpress/theme": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.5.0.tgz",
+			"integrity": "sha512-6V14snLXUqVs3fBPmGJhWkgtWcrwEe7vUS04nTl7hyI5uyL+N7LXRldWTjnzwaQL0ywBIx4u13gJU/GZqOc8dQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^6.38.0",
+				"@wordpress/private-apis": "^1.38.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.37.0.tgz",
-			"integrity": "sha512-oXWyKiYJIa9SuPRNEJiOWn2Qk0RzfxOsDqXcus1OL44swCRtSM+ypm16CJpRhZpMUcsJ6d23PBxTC97C/iiJpQ==",
+			"version": "3.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.38.0.tgz",
+			"integrity": "sha512-4eHJoNC/Ofrp+hOIf/2KqSoyIZLFIoyAhfTBrFxq3bGKNFJlOEHAJ3+tGiy77Ja93uQzrSWctZsH1CpSRYKkng==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6748,6 +6857,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -6822,6 +6932,7 @@
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -6944,6 +7055,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ast-types": {
@@ -7608,23 +7729,23 @@
 			}
 		},
 		"node_modules/cacheable": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.1.tgz",
-			"integrity": "sha512-yr+FSHWn1ZUou5LkULX/S+jhfgfnLbuKQjE40tyEd4fxGZVMbBL5ifno0J0OauykS8UiCSgHi+DV/YD+rjFxFg==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
+			"integrity": "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cacheable/memory": "^2.0.6",
-				"@cacheable/utils": "^2.3.2",
-				"hookified": "^1.14.0",
+				"@cacheable/memory": "^2.0.7",
+				"@cacheable/utils": "^2.3.3",
+				"hookified": "^1.15.0",
 				"keyv": "^5.5.5",
-				"qified": "^0.5.3"
+				"qified": "^0.6.0"
 			}
 		},
 		"node_modules/cacheable/node_modules/keyv": {
-			"version": "5.5.5",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
-			"integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8046,6 +8167,17 @@
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true
 		},
+		"node_modules/colorjs.io": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
+			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/color"
+			}
+		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -8257,9 +8389,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
-			"integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+			"integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -8647,6 +8779,13 @@
 			"engines": {
 				"node": ">=18"
 			}
+		},
+		"node_modules/csstype": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/cwd": {
 			"version": "0.10.0",
@@ -10062,14 +10201,14 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "5.5.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
-			"integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
+			"version": "5.5.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
+			"integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"prettier-linter-helpers": "^1.0.0",
-				"synckit": "^0.11.7"
+				"prettier-linter-helpers": "^1.0.1",
+				"synckit": "^0.11.12"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
@@ -11023,23 +11162,6 @@
 			},
 			"engines": {
 				"node": "^10.12.0 || >=12.0.0"
-			}
-		},
-		"node_modules/flat-cache/node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/flatted": {
@@ -13839,10 +13961,11 @@
 			"dev": true
 		},
 		"node_modules/js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -14168,9 +14291,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/lighthouse/node_modules/@puppeteer/browsers": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.0.tgz",
-			"integrity": "sha512-n6oQX6mYkG8TRPuPXmbPidkUbsSRalhmaaVAQxvH1IkQy63cwsH+kOjB3e4cpCDHg0aSvsiX9bQ4s2VB6mGWUQ==",
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.1.tgz",
+			"integrity": "sha512-YmhAxs7XPuxN0j7LJloHpfD1ylhDuFmmwMvfy/+6nBSrETT2ycL53LrhgPtR+f+GcPSybQVuQ5inWWu5MrWCpA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -14190,28 +14313,28 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core": {
-			"version": "24.34.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.34.0.tgz",
-			"integrity": "sha512-24evawO+mUGW4mvS2a2ivwLdX3gk8zRLZr9HP+7+VT2vBQnm0oh9jJEZmUE3ePJhRkYlZ93i7OMpdcoi2qNCLg==",
+			"version": "24.36.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.36.0.tgz",
+			"integrity": "sha512-P3Ou0MAFDCQ0dK1d9F9+8jTrg6JvXjUacgG0YkJQP4kbEnUOGokSDEMmMId5ZhXD5HwsHM202E9VwEpEjWfwxg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@puppeteer/browsers": "2.11.0",
-				"chromium-bidi": "12.0.1",
+				"@puppeteer/browsers": "2.11.1",
+				"chromium-bidi": "13.0.1",
 				"debug": "^4.4.3",
-				"devtools-protocol": "0.0.1534754",
+				"devtools-protocol": "0.0.1551306",
 				"typed-query-selector": "^2.12.0",
-				"webdriver-bidi-protocol": "0.3.10",
-				"ws": "^8.18.3"
+				"webdriver-bidi-protocol": "0.4.0",
+				"ws": "^8.19.0"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/chromium-bidi": {
-			"version": "12.0.1",
-			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-12.0.1.tgz",
-			"integrity": "sha512-fGg+6jr0xjQhzpy5N4ErZxQ4wF7KLEvhGZXD6EgvZKDhu7iOhZXnZhcDxPJDcwTcrD48NPzOCo84RP2lv3Z+Cg==",
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.0.1.tgz",
+			"integrity": "sha512-c+RLxH0Vg2x2syS9wPw378oJgiJNXtYXUvnVAldUlt5uaHekn0CCU7gPksNgHjrH1qFhmjVXQj4esvuthuC7OQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -14223,9 +14346,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.1534754",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
-			"integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
+			"version": "0.0.1551306",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1551306.tgz",
+			"integrity": "sha512-CFx8QdSim8iIv+2ZcEOclBKTQY6BI1IEDa7Tm9YkwAXzEWFndTEzpTo5jAUhSnq24IC7xaDw0wvGcm96+Y3PEg==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
@@ -14365,9 +14488,9 @@
 			"dev": true
 		},
 		"node_modules/lodash-es": {
-			"version": "4.17.22",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
-			"integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -14754,6 +14877,13 @@
 				"node": ">= 4.0.0"
 			}
 		},
+		"node_modules/memize": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/meow": {
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
@@ -14987,16 +15117,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/minimist-options/node_modules/arrify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/minimist-options/node_modules/is-plain-obj": {
@@ -15439,6 +15559,7 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -15962,9 +16083,9 @@
 			}
 		},
 		"node_modules/pg-protocol": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-			"integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
+			"integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -16004,6 +16125,16 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/pirates": {
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -16027,14 +16158,14 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.57.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-			"integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+			"version": "1.58.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+			"integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.57.0"
+				"playwright-core": "1.58.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -16047,9 +16178,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.57.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-			"integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+			"version": "1.58.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+			"integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -17028,13 +17159,13 @@
 			"license": "MIT"
 		},
 		"node_modules/qified": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/qified/-/qified-0.5.3.tgz",
-			"integrity": "sha512-kXuQdQTB6oN3KhI6V4acnBSZx8D2I4xzZvn9+wFLLFCoBNQY/sFnCW6c43OL7pOQ2HvGV4lnWIXNmgfp7cTWhQ==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
+			"integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hookified": "^1.13.0"
+				"hookified": "^1.14.0"
 			},
 			"engines": {
 				"node": ">=20"
@@ -17156,7 +17287,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -17189,16 +17319,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"pify": "^2.3.0"
-			}
-		},
-		"node_modules/read-cache/node_modules/pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/read-pkg": {
@@ -17603,6 +17723,23 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/robots-parser": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
@@ -17887,7 +18024,6 @@
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
 			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			}
@@ -18646,7 +18782,8 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-			"dev": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/stable-hash-x": {
 			"version": "0.2.0",
@@ -19173,9 +19310,9 @@
 			}
 		},
 		"node_modules/stylelint-scss/node_modules/mdn-data": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.25.0.tgz",
-			"integrity": "sha512-T2LPsjgUE/tgMmRXREVmwsux89DwWfNjiynOeXuLd2mX6jphGQ2YE3Ukz7LQ2VOFKiVZU/Ee1GqzHiipZCjymw==",
+			"version": "2.26.0",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.26.0.tgz",
+			"integrity": "sha512-ZqI0qjKWHMPcGUfLmlr80NPNVHIOjPMHtIOe1qXYFGS0YBZ1YKAzo9yk8W+gGrLCN0Xdv/RKxqdIsqPakEfmow==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -19296,25 +19433,25 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/file-entry-cache": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.1.tgz",
-			"integrity": "sha512-TPVFSDE7q91Dlk1xpFLvFllf8r0HyOMOlnWy7Z2HBku5H3KhIeOGInexrIeg2D64DosVB/JXkrrk6N/7Wriq4A==",
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+			"integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"flat-cache": "^6.1.19"
+				"flat-cache": "^6.1.20"
 			}
 		},
 		"node_modules/stylelint/node_modules/flat-cache": {
-			"version": "6.1.19",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.19.tgz",
-			"integrity": "sha512-l/K33newPTZMTGAnnzaiqSl6NnH7Namh8jBNjrgjprWxGmZUuxx/sJNIRaijOh3n7q7ESbhNZC+pvVZMFdeU4A==",
+			"version": "6.1.20",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
+			"integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cacheable": "^2.2.0",
+				"cacheable": "^2.3.2",
 				"flatted": "^3.3.3",
-				"hookified": "^1.13.0"
+				"hookified": "^1.15.0"
 			}
 		},
 		"node_modules/stylelint/node_modules/global-modules": {
@@ -19544,9 +19681,9 @@
 			"license": "MIT"
 		},
 		"node_modules/synckit": {
-			"version": "0.11.11",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
-			"integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+			"version": "0.11.12",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -19796,7 +19933,8 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/third-party-web": {
 			"version": "0.27.0",
@@ -20270,10 +20408,11 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.13.0.tgz",
-			"integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==",
-			"dev": true
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
 			"version": "2.0.1",
@@ -20621,9 +20760,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/webdriver-bidi-protocol": {
-			"version": "0.3.10",
-			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.10.tgz",
-			"integrity": "sha512-5LAE43jAVLOhB/QqX4bwSiv0Hg1HBfMmOuwBSXHdvg4GMGu9Y0lIq7p4R/yySu6w74WmaR4GM4H9t2IwLW7hgw==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.0.tgz",
+			"integrity": "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -20899,22 +21038,6 @@
 				}
 			}
 		},
-		"node_modules/webpack-dev-server/node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/webpack-merge": {
 			"version": "5.10.0",
 			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
@@ -21180,9 +21303,9 @@
 			}
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.19",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+			"version": "1.1.20",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wc-serial-numbers",
-	"version": "2.3.1",
+	"version": "2.3.2",
 	"description": "Sell and manage license keys, serial numbers, and secret keys easily within your WooCommerce store.",
 	"author": "ByteEver Team",
 	"license": "GPL-2.0-or-later",
@@ -19,7 +19,7 @@
 		"@byteever/scripts": "^3.0.4",
 		"@wordpress/browserslist-config": "^6.37.0",
 		"@wordpress/prettier-config": "^4.37.0",
-		"@wordpress/scripts": "^31.2.0"
+		"@wordpress/scripts": "^31.3.0"
 	},
 	"scripts": {
 		"build": "wp-scripts build && composer run makepot",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: pluginever, manikmist09
 Tags: license, license manager, serial number, serial key, woocommerce
 Tested up to: 6.9
-Stable tag: 2.3.1
+Stable tag: 2.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -250,6 +250,10 @@ Yes, you are always welcome to [provide suggestions](https://github.com/pluginev
 10. Order Notification Email with Keys
 
 == Changelog ==
+== 2.3.2 (27th Jan 2026) ==
+Fix: Corrected the product edit link in the low stock notification email.
+Fix: Prevented fatal errors caused by cron events triggering with null values.
+
 = 2.3.1 (14th Jan 2026) =
 * Fix: Support older PHP v7.4 to avoid fatal error.
 

--- a/templates/email-stock-notification.php
+++ b/templates/email-stock-notification.php
@@ -20,9 +20,14 @@
 		if ( ! $product_id ) {
 			continue;
 		}
-		$product = wc_get_product( $product_id );
 
-		printf( "<li><a href='%s' target='_blank'>%s</a> - Stock %s</li>", esc_url( get_edit_post_link( $product->get_id() ) ), esc_html( $product->get_formatted_name() ), esc_html( $stock ) );
+		$product = wc_get_product( $product_id );
+		if ( ! $product ) {
+			continue;
+		}
+
+		$edit_url = admin_url( sprintf( 'post.php?post=%d&action=edit', $product->get_id() ) );
+		printf( "<li><a href='%s' target='_blank'>%s</a> - Stock %s</li>", esc_url( $edit_url ), esc_html( $product->get_formatted_name() ), esc_html( $stock ) );
 	}
 	?>
 </ul>

--- a/wc-serial-numbers.php
+++ b/wc-serial-numbers.php
@@ -3,7 +3,7 @@
  * Plugin Name:          Serial Numbers
  * Plugin URI:           https://pluginever.com/plugins/woocommerce-serial-numbers-pro/
  * Description:          Sell and manage license keys, serial numbers, and secret keys easily within your WooCommerce store.
- * Version:              2.3.1
+ * Version:              2.3.2
  * Requires at least:    5.2
  * Tested up to:         6.9
  * Requires PHP:         7.4


### PR DESCRIPTION
## Prepare Release v2.3.2

This pull request releases version 2.3.2 of the Serial Numbers plugin for WooCommerce. The update focuses on fixing issues in the low stock notification email and preventing fatal errors caused by cron events. It also includes minor updates to documentation and dependencies.

**Bug Fixes and Improvements:**

* Fixed the product edit link in the low stock notification email to ensure it points to the correct admin URL, and added a check to prevent errors when a product is not found.
* Prevented fatal errors by adding a check for null values when cron events trigger, as noted in the changelog.

**Documentation and Meta Updates:**

* Updated the plugin version to 2.3.2 in `package.json`, `readme.txt`, `wc-serial-numbers.php`, and `languages/wc-serial-numbers.pot` to reflect the new release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L5-R5) [[3]](diffhunk://#diff-0554005800d2e069310a1284f38b55bf7468023c89a7299d79aeb519755bbafcL6-R6) [[4]](diffhunk://#diff-2b13502d9fa2ba7b54f1a03bfbd072532c6fb9372859c867a57c38ec67801d38L5-R12)
* Added changelog entries for version 2.3.2 in `readme.txt`.

**Dependency Updates:**

* Bumped `@wordpress/scripts` dependency from `^31.2.0` to `^31.3.0` in `package.json`.