### PR TITLE
Fix b8 migration regressions, v2.3.5 milestone bugs, and convert to the property API

### DIFF
--- a/includes/Actions.php
+++ b/includes/Actions.php
@@ -23,61 +23,22 @@ class Actions {
 	 * @since 1.5.6
 	 */
 	public function __construct() {
-		add_action( 'wc_serial_numbers_key_db_data', array( __CLASS__, 'decrypt_key' ) );
-		add_action( 'wc_serial_numbers_key_insert_data', array( __CLASS__, 'encrypt_key' ) );
-		add_action( 'wc_serial_numbers_key_update_data', array( __CLASS__, 'encrypt_key' ) );
-		add_action( 'wc_serial_numbers_key_insert', array( __CLASS__, 'enable_product' ) );
+		add_action( 'wc_serial_numbers_key_inserted', array( __CLASS__, 'enable_product' ) );
 		add_action( 'wc_serial_numbers_key_deleted', array( __CLASS__, 'delete_activations' ) );
 		add_action( 'wc_serial_numbers_activation_inserted', array( __CLASS__, 'update_activation_count' ) );
 		add_action( 'wc_serial_numbers_activation_deleted', array( __CLASS__, 'update_activation_count' ) );
 	}
 
 	/**
-	 * Decrypt key.
+	 * Enable serial numbers on the product when a key is inserted.
 	 *
-	 * @param array $data The key data.
-	 *
-	 * @since 1.4.6
-	 */
-	public static function decrypt_key( $data ) {
-		if ( ! empty( $data['serial_key'] ) ) {
-			$data['serial_key'] = wcsn_decrypt_key( $data['serial_key'] );
-		}
-
-		return $data;
-	}
-
-	/**
-	 * Encrypt key.
-	 *
-	 * @param array $data The key data.
+	 * @param Key $key The inserted key object.
 	 *
 	 * @since 1.4.6
 	 */
-	public static function encrypt_key( $data ) {
-		if ( ! empty( $data['serial_key'] ) ) {
-			$data['serial_key'] = wcsn_encrypt_key( $data['serial_key'] );
-		}
-
-		return $data;
-	}
-
-	/**
-	 * Enable product.
-	 *
-	 * @param int $key_id The key ID.
-	 *
-	 * @since 1.4.6
-	 */
-	public static function enable_product( $key_id ) {
-		$key = Key::find( $key_id );
-
-		if ( $key ) {
-			$product_id = $key->get_product_id();
-
-			if ( $product_id ) {
-				update_post_meta( $product_id, '_is_serial_number', 'yes' );
-			}
+	public static function enable_product( $key ) {
+		if ( $key && $key->product_id ) {
+			update_post_meta( $key->product_id, '_is_serial_number', 'yes' );
 		}
 	}
 

--- a/includes/Actions.php
+++ b/includes/Actions.php
@@ -50,7 +50,7 @@ class Actions {
 	 * @since 1.4.6
 	 */
 	public static function delete_activations( $key ) {
-		$activations = $key->get_activations();
+		$activations = $key->activations;
 		if ( $activations ) {
 			foreach ( $activations as $activation ) {
 				$activation->delete();
@@ -82,7 +82,7 @@ class Actions {
 	 * @since 1.0.0
 	 */
 	public static function update_activation_count( $activation ) {
-		$key = Key::find( $activation->get_serial_id() );
+		$key = Key::find( $activation->serial_id );
 		if ( $key ) {
 			$key->recount_remaining_activation();
 		}

--- a/includes/Admin/ListTables/ActivationsTable.php
+++ b/includes/Admin/ListTables/ActivationsTable.php
@@ -238,7 +238,7 @@ class ActivationsTable extends ListTable {
 		);
 		$actions['delete'] = sprintf( '<a href="%1$s">%2$s</a>', wp_nonce_url( $delete_url, 'bulk-activations' ), __( 'Delete', 'wc-serial-numbers' ) );
 
-		return sprintf( '<code class="wcsn-activation-instance">%1$s</code> %2$s', esc_html( $activation->get_instance() ), $this->row_actions( $actions ) );
+		return sprintf( '<code class="wcsn-activation-instance">%1$s</code> %2$s', esc_html( $activation->instance ), $this->row_actions( $actions ) );
 	}
 
 	/**
@@ -249,7 +249,7 @@ class ActivationsTable extends ListTable {
 	 * @since 1.4.6
 	 */
 	protected function column_product( $activation ) {
-		return esc_html( $activation->get_product_title() );
+		return esc_html( $activation->product_title );
 	}
 
 	/**
@@ -260,9 +260,9 @@ class ActivationsTable extends ListTable {
 	 * @since 1.4.6
 	 */
 	protected function column_serial_id( $activation ) {
-		$edit_url = admin_url( 'admin.php?page=wc-serial-numbers&id=' . $activation->get_serial_id() );
+		$edit_url = admin_url( 'admin.php?page=wc-serial-numbers&id=' . $activation->serial_id );
 
-		return sprintf( '<a href="%1$s">#%2$s</a>', esc_url( $edit_url ), esc_html( $activation->get_serial_id() ) );
+		return sprintf( '<a href="%1$s">#%2$s</a>', esc_url( $edit_url ), esc_html( $activation->serial_id ) );
 	}
 
 	/**
@@ -273,7 +273,7 @@ class ActivationsTable extends ListTable {
 	 * @since 1.4.6
 	 */
 	protected function column_platform( $activation ) {
-		return empty( $activation->get_platform() ) ? '&mdash;' : esc_html( $activation->get_platform() );
+		return empty( $activation->platform ) ? '&mdash;' : esc_html( $activation->platform );
 	}
 
 	/**
@@ -284,6 +284,6 @@ class ActivationsTable extends ListTable {
 	 * @since 1.4.6
 	 */
 	protected function column_activation_time( $activation ) {
-		return empty( $activation->get_activation_time() ) ? '&mdash;' : esc_html( $activation->get_activation_time() );
+		return empty( $activation->activation_time ) ? '&mdash;' : esc_html( $activation->activation_time );
 	}
 }

--- a/includes/Admin/ListTables/KeysTable.php
+++ b/includes/Admin/ListTables/KeysTable.php
@@ -451,7 +451,7 @@ class KeysTable extends ListTable {
 	 * @since 1.4.6
 	 */
 	protected function column_order( $item ) {
-		$order = $item->get_order();
+		$order = $item->order;
 		if ( empty( $order ) ) {
 			return '&mdash;';
 		}
@@ -515,17 +515,17 @@ class KeysTable extends ListTable {
 	 * @since 1.4.6
 	 */
 	protected function column_valid_for( $key ) {
-		if ( ! empty( $key->get_validity() ) ) {
+		if ( ! empty( $key->validity ) ) {
 			return wp_kses_post(
 				sprintf(
 					// translators: %1$s: validity, %2$s: validity.
 					_n(
 						'<b>%s</b> Day <br><small>After purchase</small>',
 						'<b>%s</b> Days <br><small>After purchase</small>',
-						$key->get_validity(),
+						$key->validity,
 						'wc-serial-numbers'
 					),
-					number_format_i18n( $key->get_validity() )
+					number_format_i18n( $key->validity )
 				)
 			);
 		}

--- a/includes/Admin/Menus.php
+++ b/includes/Admin/Menus.php
@@ -206,7 +206,7 @@ class Menus {
 		$edit = isset( $_GET['edit'] ) ? absint( $_GET['edit'] ) : 0;
 		if ( $edit ) {
 			$key = Key::find( $edit );
-			if ( ! $key->exists() ) {
+			if ( ! $key || ! $key->exists() ) {
 				wp_safe_redirect( remove_query_arg( 'edit' ) );
 				exit();
 			}

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -265,19 +265,19 @@ class Orders {
 			$data = array(
 				'key'              => array(
 					'label' => __( 'Key', 'wc-serial-numbers' ),
-					'value' => '<code>' . $key->get_key() . '</code>',
+					'value' => '<code>' . $key->key . '</code>',
 				),
 				'expire_date'      => array(
 					'label' => __( 'Expire date', 'wc-serial-numbers' ),
-					'value' => $key->get_expire_date() ? $key->get_expire_date() : __( 'Lifetime', 'wc-serial-numbers' ),
+					'value' => $key->expire_date ? $key->expire_date : __( 'Lifetime', 'wc-serial-numbers' ),
 				),
 				'activation_limit' => array(
 					'label' => __( 'Activation limit', 'wc-serial-numbers' ),
-					'value' => $key->get_activation_limit() ? $key->get_activation_limit() : __( 'Unlimited', 'wc-serial-numbers' ),
+					'value' => $key->activation_limit ? $key->activation_limit : __( 'Unlimited', 'wc-serial-numbers' ),
 				),
 				'status'           => array(
 					'label' => __( 'Status', 'wc-serial-numbers' ),
-					'value' => $key->get_status_label(),
+					'value' => $key->status_label,
 				),
 			);
 
@@ -303,7 +303,7 @@ class Orders {
 				<?php endforeach; ?>
 				<tr>
 					<td colspan="2">
-						<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-serial-numbers&edit=' . $key->get_id() ) ); ?>"><?php esc_html_e( 'View Details', 'wc-serial-numbers' ); ?></a>
+						<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-serial-numbers&edit=' . $key->id ) ); ?>"><?php esc_html_e( 'View Details', 'wc-serial-numbers' ); ?></a>
 					</td>
 				</tr>
 				</tbody>

--- a/includes/Admin/Requests.php
+++ b/includes/Admin/Requests.php
@@ -78,7 +78,7 @@ class Requests {
 		$add = empty( $data['id'] ) ? true : false;
 		if ( $add ) {
 			// Adding manually so let's enable to product and set the source.
-			$product_id = $key->get_product_id();
+			$product_id = $key->product_id;
 			update_post_meta( $product_id, '_is_serial_number', 'yes' );
 			update_post_meta( $product_id, '_serial_key_source', 'custom_source' );
 
@@ -87,7 +87,7 @@ class Requests {
 			WCSN()->add_notice( __( 'Key updated successfully.', 'wc-serial-numbers' ) );
 		}
 
-		$redirect_to = admin_url( 'admin.php?page=wc-serial-numbers&edit=' . $key->get_id() );
+		$redirect_to = admin_url( 'admin.php?page=wc-serial-numbers&edit=' . $key->id );
 		wp_safe_redirect( $redirect_to );
 		exit;
 	}

--- a/includes/Admin/views/html-edit-key.php
+++ b/includes/Admin/views/html-edit-key.php
@@ -41,8 +41,8 @@ defined( 'ABSPATH' ) || exit;
 								<?php
 								printf(
 									'<option value="%d" selected="selected">%s</option>',
-									esc_attr( $key->get_product_id() ),
-									esc_html( $key->get_product_title() )
+									esc_attr( $key->product_id ),
+									esc_html( $key->product_title )
 								);
 								?>
 							</select>
@@ -56,7 +56,7 @@ defined( 'ABSPATH' ) || exit;
 								<?php esc_html_e( 'Serial key', 'wc-serial-numbers' ); ?>
 								<abbr title="required"></abbr>
 							</label>
-							<textarea name="serial_key" id="serial_key" required="required" placeholder="serial-####-####-####"><?php echo wp_kses_post( $key->get_key() ); ?></textarea>
+							<textarea name="serial_key" id="serial_key" required="required" placeholder="serial-####-####-####"><?php echo wp_kses_post( $key->key ); ?></textarea>
 							<p class="description">
 								<?php esc_html_e( 'Enter your serial key, also supports multiline.  For example: 4CE0460D0G-4CE0460D1G-4CE0460D2G', 'wc-serial-numbers' ); ?>
 							</p>
@@ -66,7 +66,7 @@ defined( 'ABSPATH' ) || exit;
 							<div class="pev-form-field">
 								<label for="activation_limit"><?php esc_html_e( 'Activation limit', 'wc-serial-numbers' ); ?></label>
 
-								<input type="number" name="activation_limit" id="activation_limit" value="<?php echo esc_attr( $key->get_activation_limit() ); ?>" min="0" step="1"/>
+								<input type="number" name="activation_limit" id="activation_limit" value="<?php echo esc_attr( $key->activation_limit ); ?>" min="0" step="1"/>
 								<p class="description">
 									<?php esc_html_e( 'Maximum number of times the key can be used to activate the software. If the product is not software, keep it blank.', 'wc-serial-numbers' ); ?>
 								</p>
@@ -77,7 +77,7 @@ defined( 'ABSPATH' ) || exit;
 									<?php esc_html_e( 'Valid for', 'wc-serial-numbers' ); ?>
 								</label>
 								<div class="pev-form-field__group">
-									<input type="number" name="validity" id="validity" value="<?php echo esc_attr( $key->get_validity() ); ?>" min="0" step="1"/>
+									<input type="number" name="validity" id="validity" value="<?php echo esc_attr( $key->validity ); ?>" min="0" step="1"/>
 									<div class="addon">
 										<?php esc_html_e( 'Days', 'wc-serial-numbers' ); ?>
 									</div>
@@ -93,7 +93,7 @@ defined( 'ABSPATH' ) || exit;
 							</label>
 							<select id="status" name="status">
 								<?php foreach ( wcsn_get_key_statuses() as $status => $option ) : ?>
-									<?php printf( '<option value="%s" %s>%s</option>', esc_attr( $status ), selected( $key->get_status(), $status, false ), esc_html( $option ) ); ?>
+									<?php printf( '<option value="%s" %s>%s</option>', esc_attr( $status ), selected( $key->status, $status, false ), esc_html( $option ) ); ?>
 								<?php endforeach; ?>
 							</select>
 							<p class="description"><?php esc_html_e( 'Serial key status auto-updates with order status. Avoid manual changes.', 'wc-serial-numbers' ); ?></p>
@@ -107,8 +107,8 @@ defined( 'ABSPATH' ) || exit;
 								<?php
 								printf(
 									'<option value="%d" selected="selected">%s</option>',
-									esc_attr( $key->get_order_id() ),
-									esc_html( $key->get_order_title() )
+									esc_attr( $key->order_id ),
+									esc_html( $key->order_title )
 								);
 								?>
 							</select>
@@ -127,13 +127,13 @@ defined( 'ABSPATH' ) || exit;
 					</div>
 					<div class="pev-card__footer">
 						<?php if ( $key->exists() ) : ?>
-							<a class="del" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'action', 'delete', admin_url( 'admin.php?page=wc-serial-numbers&id=' . $key->get_id() ) ), 'bulk-keys' ) ); ?>"><?php esc_html_e( 'Delete', 'wc-serial-numbers' ); ?></a>
+							<a class="del" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'action', 'delete', admin_url( 'admin.php?page=wc-serial-numbers&id=' . $key->id ) ), 'bulk-keys' ) ); ?>"><?php esc_html_e( 'Delete', 'wc-serial-numbers' ); ?></a>
 						<?php endif; ?>
 						<button class="button button-primary"><?php esc_html_e( 'Save Key', 'wc-serial-numbers' ); ?></button>
 					</div>
 				</div>
 
-				<?php if ( $key->get_order() ) : ?>
+				<?php if ( $key->order ) : ?>
 					<div class="pev-card">
 						<div class="pev-card__header">
 							<h2 class="pev-card__title"><?php esc_html_e( 'Customer details', 'wc-serial-numbers' ); ?></h2>
@@ -146,7 +146,7 @@ defined( 'ABSPATH' ) || exit;
 										<?php esc_html_e( 'Name', 'wc-serial-numbers' ); ?>
 									</th>
 									<td>
-										<?php echo esc_html( $key->get_order()->get_formatted_billing_full_name() ); ?>
+										<?php echo esc_html( $key->order->get_formatted_billing_full_name() ); ?>
 									</td>
 								</tr>
 								<tr>
@@ -154,7 +154,7 @@ defined( 'ABSPATH' ) || exit;
 										<?php esc_html_e( 'Email', 'wc-serial-numbers' ); ?>
 									</th>
 									<td>
-										<?php echo esc_html( $key->get_order()->get_billing_email() ); ?>
+										<?php echo esc_html( $key->order->get_billing_email() ); ?>
 									</td>
 								</tr>
 								<tr>
@@ -162,7 +162,7 @@ defined( 'ABSPATH' ) || exit;
 										<?php esc_html_e( 'Address', 'wc-serial-numbers' ); ?>
 									</th>
 									<td>
-										<?php echo wp_kses_post( $key->get_order()->get_formatted_billing_address() ); ?>
+										<?php echo wp_kses_post( $key->order->get_formatted_billing_address() ); ?>
 									</td>
 								</tr>
 
@@ -171,13 +171,13 @@ defined( 'ABSPATH' ) || exit;
 										<?php esc_html_e( 'Phone', 'wc-serial-numbers' ); ?>
 									</th>
 									<td>
-										<?php echo esc_html( $key->get_order()->get_billing_phone() ); ?>
+										<?php echo esc_html( $key->order->get_billing_phone() ); ?>
 									</td>
 								</tr>
 								<tr>
 									<th>&nbsp;</th>
 									<td>
-										<a href="<?php echo esc_url( admin_url( 'post.php?post=' . $key->get_order_id() . '&action=edit' ) ); ?>" class="button">
+										<a href="<?php echo esc_url( admin_url( 'post.php?post=' . $key->order_id . '&action=edit' ) ); ?>" class="button">
 											<?php esc_html_e( 'View Order', 'wc-serial-numbers' ); ?>
 										</a>
 									</td>
@@ -192,7 +192,7 @@ defined( 'ABSPATH' ) || exit;
 		</div><!-- .pev-poststuff -->
 
 		<input type="hidden" name="action" value="wcsn_edit_key">
-		<input type="hidden" name="id" value="<?php echo esc_attr( $key->get_id() ); ?>">
+		<input type="hidden" name="id" value="<?php echo esc_attr( $key->id ); ?>">
 		<?php wp_nonce_field( 'wcsn_edit_key' ); ?>
 	</form>
 </div>

--- a/includes/Compat.php
+++ b/includes/Compat.php
@@ -77,27 +77,27 @@ class Compat {
 			$data = array(
 				'key'              => array(
 					'label' => __( 'Key', 'wc-serial-numbers' ),
-					'value' => '<code>' . $key->get_key() . '</code>',
+					'value' => '<code>' . $key->key . '</code>',
 				),
 				'expire_date'      => array(
 					'label' => __( 'Expire date', 'wc-serial-numbers' ),
-					'value' => $key->get_expire_date() ? $key->get_expire_date() : __( 'Lifetime', 'wc-serial-numbers' ),
+					'value' => $key->expire_date ? $key->expire_date : __( 'Lifetime', 'wc-serial-numbers' ),
 				),
 				'activation_limit' => array(
 					'label' => __( 'Activation limit', 'wc-serial-numbers' ),
-					'value' => $key->get_activation_limit() ? $key->get_activation_limit() : __( 'Unlimited', 'wc-serial-numbers' ),
+					'value' => $key->activation_limit ? $key->activation_limit : __( 'Unlimited', 'wc-serial-numbers' ),
 				),
 				'activation_count' => array(
 					'label' => __( 'Activation count', 'wc-serial-numbers' ),
-					'value' => $key->get_activation_count(),
+					'value' => $key->activation_count,
 				),
 				'activation_email' => array(
 					'label' => __( 'Activation email', 'wc-serial-numbers' ),
-					'value' => $key->get_customer_email(),
+					'value' => $key->customer_email,
 				),
 				'status'           => array(
 					'label' => __( 'Status', 'wc-serial-numbers' ),
-					'value' => $key->get_status_label(),
+					'value' => $key->status_label,
 				),
 			);
 

--- a/includes/Deprecated/Functions.php
+++ b/includes/Deprecated/Functions.php
@@ -438,3 +438,58 @@ add_filter( 'wc_serial_numbers_order_table_columns', 'wc_serial_numbers_control_
 function wc_serial_numbers_validate_boolean( $string ) {
 	return filter_var( $string, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
 }
+
+/**
+ * Translate the legacy `customer_id` key query argument into a native condition.
+ *
+ * Keys have no customer column; the customer is derived from the order, so the
+ * argument is resolved to the customer's order IDs and applied as an
+ * `order_id IN (...)` condition. An empty list is left to the query layer, which
+ * ignores an empty IN rather than constraining the query.
+ *
+ * @deprecated 2.3.5 Pass a native `order_id__in` argument instead.
+ */
+add_filter(
+	'wc_serial_numbers_key_query_args',
+	function ( $args, $query ) {
+		if ( empty( $args['customer_id'] ) ) {
+			return $args;
+		}
+
+		$order_ids = wc_get_orders(
+			array(
+				'customer_id' => absint( $args['customer_id'] ),
+				'limit'       => - 1,
+				'return'      => 'ids',
+			)
+		);
+
+		$query->where( 'order_id', 'IN', $order_ids );
+		unset( $args['customer_id'] );
+
+		return $args;
+	},
+	10,
+	2
+);
+
+/**
+ * Drop a zero `product_id` key query argument.
+ *
+ * A key always has a real product, so a `product_id` of 0 means "any product"
+ * rather than a literal match. Without this the query layer would treat it as
+ * `product_id = 0` and return nothing, which is how the "All Products" export
+ * came back empty.
+ *
+ * @deprecated 2.3.5 Stop passing a zero `product_id` from the export.
+ */
+add_filter(
+	'wc_serial_numbers_key_query_args',
+	function ( $args ) {
+		if ( isset( $args['product_id'] ) && empty( $args['product_id'] ) ) {
+			unset( $args['product_id'] );
+		}
+
+		return $args;
+	}
+);

--- a/includes/Deprecated/Functions.php
+++ b/includes/Deprecated/Functions.php
@@ -153,7 +153,7 @@ function wc_serial_numbers_update_serial_number_status( $id, $status ) {
 	if ( ! $key ) {
 		return new WP_Error( 'invalid_data', __( 'Serial number not found.', 'wc-serial-numbers' ) );
 	}
-	$key->set_status( $status );
+	$key->status = $status;
 
 	return $key->save();
 }

--- a/includes/Functions/Template.php
+++ b/includes/Functions/Template.php
@@ -40,32 +40,32 @@ function wcsn_display_key_html( $key, $output = true ) {
 	$properties = array(
 		'key'              => array(
 			'label'    => __( 'Key', 'wc-serial-numbers' ),
-			'value'    => '<code>' . $key->get_key() . '</code>',
+			'value'    => '<code>' . $key->key . '</code>',
 			'priority' => 10,
 		),
 		'activation_email' => array(
 			'label'    => __( 'Activation Email', 'wc-serial-numbers' ),
-			'value'    => $key->get_customer_email(),
+			'value'    => $key->customer_email,
 			'priority' => 20,
 		),
 		'activation_limit' => array(
 			'label'    => __( 'Activation Limit', 'wc-serial-numbers' ),
-			'value'    => ! empty( $key->get_activation_limit() ) ? number_format_i18n( $key->get_activation_limit() ) : __( 'None', 'wc-serial-numbers' ),
+			'value'    => ! empty( $key->activation_limit ) ? number_format_i18n( $key->activation_limit ) : __( 'None', 'wc-serial-numbers' ),
 			'priority' => 30,
 		),
 		'activation_count' => array(
 			'label'    => __( 'Activation Count', 'wc-serial-numbers' ),
-			'value'    => ! empty( $key->get_activation_count() ) ? number_format_i18n( $key->get_activation_count() ) : __( 'None', 'wc-serial-numbers' ),
+			'value'    => ! empty( $key->activation_count ) ? number_format_i18n( $key->activation_count ) : __( 'None', 'wc-serial-numbers' ),
 			'priority' => 40,
 		),
 		'expire_date'      => array(
 			'label'    => __( 'Expire Date', 'wc-serial-numbers' ),
-			'value'    => ! empty( $key->get_expire_date() ) ? $key->get_expire_date() : __( 'Lifetime', 'wc-serial-numbers' ),
+			'value'    => ! empty( $key->expire_date ) ? $key->expire_date : __( 'Lifetime', 'wc-serial-numbers' ),
 			'priority' => 50,
 		),
 	);
 
-	$status = $key->get_status();
+	$status = $key->status;
 	if ( 'sold' === $status ) {
 		$status = '<span style="color: #5b841b;">' . __( 'Active', 'wc-serial-numbers' ) . '</span>';
 	} elseif ( 'expired' === $status ) {

--- a/includes/Models/Key.php
+++ b/includes/Models/Key.php
@@ -228,67 +228,15 @@ class Key extends Model {
 	}
 
 	/**
-	 * Translate the legacy `customer_id` query argument into a native condition.
-	 *
-	 * Keys have no customer column; the customer is derived from the order. The
-	 * argument is resolved to the customer's order IDs and applied as an
-	 * `order_id IN (...)` condition. An empty list is left to the query layer,
-	 * which ignores an empty IN rather than constraining the query.
-	 *
-	 * @param array                                     $args Query arguments.
-	 * @param \WooCommerceSerialNumbers\B8\Models\Query $query Query object.
-	 *
-	 * @since 1.0.0
-	 * @return array Query arguments.
-	 */
-	public static function prepare_customer_query( $args, $query ) {
-		if ( empty( $args['customer_id'] ) ) {
-			return $args;
-		}
-
-		$order_ids = wc_get_orders(
-			array(
-				'customer_id' => absint( $args['customer_id'] ),
-				'limit'       => - 1,
-				'return'      => 'ids',
-			)
-		);
-
-		$query->where( 'order_id', 'IN', $order_ids );
-
-		unset( $args['customer_id'] );
-
-		return $args;
-	}
-
-	/**
-	 * Drop a zero `product_id` query argument.
-	 *
-	 * A key always has a real product (product_id is required, min:1), so a
-	 * `product_id` of 0 means "any product" rather than a literal match. The
-	 * query layer would otherwise treat 0 as `product_id = 0` and return
-	 * nothing, which is how the "All Products" export came back empty.
-	 *
-	 * @param array                                     $args Query arguments.
-	 * @param \WooCommerceSerialNumbers\B8\Models\Query $query Query object.
-	 *
-	 * @since 1.0.0
-	 * @return array Query arguments.
-	 */
-	public static function prepare_product_query( $args, $query ) {
-		if ( isset( $args['product_id'] ) && empty( $args['product_id'] ) ) {
-			unset( $args['product_id'] );
-		}
-
-		return $args;
-	}
-
-	/**
 	 * Bootstrap the model.
 	 *
 	 * Wires the encryption boundary into the native read and query hooks:
 	 * the serial key is decrypted when read from the database and search
 	 * terms are encrypted to match the value at rest.
+	 *
+	 * The legacy `customer_id` and zero `product_id` query arguments are
+	 * translated separately in includes/Deprecated/Functions.php so that
+	 * compatibility shim can be removed without touching the model.
 	 *
 	 * @since 1.0.0
 	 * @return void
@@ -297,8 +245,6 @@ class Key extends Model {
 		parent::bootstrap();
 		$this->on_filter( 'serial_key', 'wcsn_decrypt_key' );
 		$this->on_filter( 'query_args', array( static::class, 'prepare_search' ), 10, 2 );
-		$this->on_filter( 'query_args', array( static::class, 'prepare_customer_query' ), 10, 2 );
-		$this->on_filter( 'query_args', array( static::class, 'prepare_product_query' ), 10, 2 );
 	}
 
 	/*

--- a/includes/Models/Key.php
+++ b/includes/Models/Key.php
@@ -228,6 +228,62 @@ class Key extends Model {
 	}
 
 	/**
+	 * Translate the legacy `customer_id` query argument into a native condition.
+	 *
+	 * Keys have no customer column; the customer is derived from the order. The
+	 * argument is resolved to the customer's order IDs and applied as an
+	 * `order_id IN (...)` condition. An empty list is left to the query layer,
+	 * which ignores an empty IN rather than constraining the query.
+	 *
+	 * @param array                                     $args Query arguments.
+	 * @param \WooCommerceSerialNumbers\B8\Models\Query $query Query object.
+	 *
+	 * @since 1.0.0
+	 * @return array Query arguments.
+	 */
+	public static function prepare_customer_query( $args, $query ) {
+		if ( empty( $args['customer_id'] ) ) {
+			return $args;
+		}
+
+		$order_ids = wc_get_orders(
+			array(
+				'customer_id' => absint( $args['customer_id'] ),
+				'limit'       => - 1,
+				'return'      => 'ids',
+			)
+		);
+
+		$query->where( 'order_id', 'IN', $order_ids );
+
+		unset( $args['customer_id'] );
+
+		return $args;
+	}
+
+	/**
+	 * Drop a zero `product_id` query argument.
+	 *
+	 * A key always has a real product (product_id is required, min:1), so a
+	 * `product_id` of 0 means "any product" rather than a literal match. The
+	 * query layer would otherwise treat 0 as `product_id = 0` and return
+	 * nothing, which is how the "All Products" export came back empty.
+	 *
+	 * @param array                                     $args Query arguments.
+	 * @param \WooCommerceSerialNumbers\B8\Models\Query $query Query object.
+	 *
+	 * @since 1.0.0
+	 * @return array Query arguments.
+	 */
+	public static function prepare_product_query( $args, $query ) {
+		if ( isset( $args['product_id'] ) && empty( $args['product_id'] ) ) {
+			unset( $args['product_id'] );
+		}
+
+		return $args;
+	}
+
+	/**
 	 * Bootstrap the model.
 	 *
 	 * Wires the encryption boundary into the native read and query hooks:
@@ -241,6 +297,8 @@ class Key extends Model {
 		parent::bootstrap();
 		$this->on_filter( 'serial_key', 'wcsn_decrypt_key' );
 		$this->on_filter( 'query_args', array( static::class, 'prepare_search' ), 10, 2 );
+		$this->on_filter( 'query_args', array( static::class, 'prepare_customer_query' ), 10, 2 );
+		$this->on_filter( 'query_args', array( static::class, 'prepare_product_query' ), 10, 2 );
 	}
 
 	/*

--- a/includes/RestAPI.php
+++ b/includes/RestAPI.php
@@ -160,18 +160,18 @@ class RestAPI {
 		}
 
 		// Check if the key has order ID.
-		if ( empty( $serial_key->get_order_id() ) || ( $serial_key->get_order_id() && ! get_post( $serial_key->get_order_id() ) ) ) {
+		if ( empty( $serial_key->order_id ) || ( $serial_key->order_id && ! get_post( $serial_key->order_id ) ) ) {
 			return new \WP_Error( 'invalid_key', __( 'Serial key is not authorized to use.', 'wc-serial-numbers' ), array( 'status' => 400 ) );
 		}
 
 		// Check if order status is completed.
-		$order = wc_get_order( $serial_key->get_order_id() );
+		$order = wc_get_order( $serial_key->order_id );
 		if ( ! $order || ! apply_filters( 'wc_serial_numbers_api_validate_order_status', 'completed' === $order->get_status(), $order ) ) {
 			return new \WP_Error( 'invalid_order', __( 'Please complete your order to activate the serial key.', 'wc-serial-numbers' ), array( 'status' => 400 ) );
 		}
 
 		// Check if key is valid for the product.
-		if ( $serial_key->get_product_id() !== $product_id ) {
+		if ( $serial_key->product_id !== $product_id ) {
 			return new \WP_Error( 'invalid_product_key', __( 'Serial key is not valid for this product.', 'wc-serial-numbers' ), array( 'status' => 400 ) );
 		}
 
@@ -181,12 +181,12 @@ class RestAPI {
 		}
 
 		// based on key status send response.
-		if ( 'expired' === $serial_key->get_status() ) {
+		if ( 'expired' === $serial_key->status ) {
 			return new \WP_Error( 'expired_key', __( 'Serial key is expired.', 'wc-serial-numbers' ), array( 'status' => 400 ) );
-		} elseif ( 'cancelled' === $serial_key->get_status() ) {
+		} elseif ( 'cancelled' === $serial_key->status ) {
 			return new \WP_Error( 'key_cancelled', __( 'Serial key is cancelled.', 'wc-serial-numbers' ), array( 'status' => 400 ) );
 
-		} elseif ( 'sold' !== $serial_key->get_status() ) {
+		} elseif ( 'sold' !== $serial_key->status ) {
 			return new \WP_Error( 'invalid_key_status', __( 'Invalid serial key.', 'wc-serial-numbers' ), array( 'status' => 400 ) );
 		}
 
@@ -214,13 +214,13 @@ class RestAPI {
 		$response = array(
 			'code'             => 'key_valid',
 			'message'          => __( 'Serial key is valid.', 'wc-serial-numbers' ),
-			'activation_limit' => $serial_key->get_activation_limit(),
-			'activation_count' => $serial_key->get_activation_count(),
-			'activations_left' => $serial_key->get_activations_left(),
-			'expire_date'      => $serial_key->get_expire_date(),
-			'status'           => 'sold' === $serial_key->get_status() ? 'active' : $serial_key->get_status(),
-			'product_id'       => $serial_key->get_product_id(),
-			'product'          => $serial_key->get_product_title(),
+			'activation_limit' => $serial_key->activation_limit,
+			'activation_count' => $serial_key->activation_count,
+			'activations_left' => $serial_key->activations_left,
+			'expire_date'      => $serial_key->expire_date,
+			'status'           => 'sold' === $serial_key->status ? 'active' : $serial_key->status,
+			'product_id'       => $serial_key->product_id,
+			'product'          => $serial_key->product_title,
 			'activations'      => array_map(
 				static function ( $activation ) {
 					return $activation->to_array();
@@ -229,7 +229,7 @@ class RestAPI {
 			),
 
 			// Deprecated.
-			'remaining'        => $serial_key->get_activations_left(),
+			'remaining'        => $serial_key->activations_left,
 		);
 
 		// send response.
@@ -265,7 +265,7 @@ class RestAPI {
 		// Check if instance is already activated.
 		$activation = Activation::find(
 			array(
-				'serial_id' => $serial_key->get_id(),
+				'serial_id' => $serial_key->id,
 				'instance'  => $instance,
 			)
 		);
@@ -275,14 +275,14 @@ class RestAPI {
 		}
 
 		// Check if key is already activated.
-		if ( $serial_key->get_activations_left() <= 0 ) {
+		if ( $serial_key->activations_left <= 0 ) {
 			return new \WP_Error( 'no_activations_left', __( 'Activation limit reached.', 'wc-serial-numbers' ), array( 'status' => 400 ) );
 		}
 
 		// Create activation.
 		$activation = Activation::insert(
 			array(
-				'serial_id' => $serial_key->get_id(),
+				'serial_id' => $serial_key->id,
 				'instance'  => $instance,
 				'platform'  => $platform,
 			)
@@ -294,14 +294,14 @@ class RestAPI {
 			'code'             => 'key_activated',
 			'message'          => __( 'Serial key is activated.', 'wc-serial-numbers' ),
 			'activated'        => true,
-			'instance'         => $activation->get_instance(),
-			'platform'         => $activation->get_platform(),
-			'activation_limit' => $serial_key->get_activation_limit(),
-			'activation_count' => $serial_key->get_activation_count(),
-			'activations_left' => $serial_key->get_activations_left(),
-			'expires_at'       => $serial_key->get_expire_date(),
-			'product_id'       => $serial_key->get_product_id(),
-			'product'          => $serial_key->get_product_title(),
+			'instance'         => $activation->instance,
+			'platform'         => $activation->platform,
+			'activation_limit' => $serial_key->activation_limit,
+			'activation_count' => $serial_key->activation_count,
+			'activations_left' => $serial_key->activations_left,
+			'expires_at'       => $serial_key->expire_date,
+			'product_id'       => $serial_key->product_id,
+			'product'          => $serial_key->product_title,
 			'activations'      => array_map(
 				static function ( $activation ) {
 					return $activation->to_array();
@@ -310,7 +310,7 @@ class RestAPI {
 			),
 
 			// Deprecated.
-			'remaining'        => $serial_key->get_activations_left(),
+			'remaining'        => $serial_key->activations_left,
 		);
 
 		// send response.
@@ -342,7 +342,7 @@ class RestAPI {
 
 		$activation = Activation::find(
 			array(
-				'serial_id' => $serial_key->get_id(),
+				'serial_id' => $serial_key->id,
 				'instance'  => $instance,
 			)
 		);
@@ -358,13 +358,13 @@ class RestAPI {
 			'code'             => 'key_deactivated',
 			'message'          => __( 'Serial key is deactivated.', 'wc-serial-numbers' ),
 			'deactivated'      => true,
-			'instance'         => $activation->get_instance(),
-			'activation_limit' => $serial_key->get_activation_limit(),
-			'activation_count' => $serial_key->get_activation_count(),
-			'activations_left' => $serial_key->get_activations_left(),
-			'expires_at'       => $serial_key->get_expire_date(),
-			'product_id'       => $serial_key->get_product_id(),
-			'product'          => $serial_key->get_product_title(),
+			'instance'         => $activation->instance,
+			'activation_limit' => $serial_key->activation_limit,
+			'activation_count' => $serial_key->activation_count,
+			'activations_left' => $serial_key->activations_left,
+			'expires_at'       => $serial_key->expire_date,
+			'product_id'       => $serial_key->product_id,
+			'product'          => $serial_key->product_title,
 			'activations'      => array_map(
 				static function ( $activation ) {
 					return $activation->to_array();
@@ -373,7 +373,7 @@ class RestAPI {
 			),
 
 			// Deprecated.
-			'remaining'        => $serial_key->get_activations_left(),
+			'remaining'        => $serial_key->activations_left,
 		);
 
 		// send response.
@@ -400,9 +400,9 @@ class RestAPI {
 
 		$response = array(
 			'code'       => 'version_checked',
-			'product_id' => $serial_key->get_product_id(),
-			'product'    => $serial_key->get_product_title(),
-			'version'    => get_post_meta( $serial_key->get_product_id(), '_software_version', true ),
+			'product_id' => $serial_key->product_id,
+			'product'    => $serial_key->product_title,
+			'version'    => get_post_meta( $serial_key->product_id, '_software_version', true ),
 		);
 
 		// send response.

--- a/includes/RestAPI.php
+++ b/includes/RestAPI.php
@@ -221,11 +221,11 @@ class RestAPI {
 			'status'           => 'sold' === $serial_key->get_status() ? 'active' : $serial_key->get_status(),
 			'product_id'       => $serial_key->get_product_id(),
 			'product'          => $serial_key->get_product_title(),
-			'activations'      => $serial_key->get_activations(
-				array(
-					'limit'  => - 1,
-					'output' => ARRAY_A,
-				)
+			'activations'      => array_map(
+				static function ( $activation ) {
+					return $activation->to_array();
+				},
+				$serial_key->activations
 			),
 
 			// Deprecated.
@@ -302,11 +302,11 @@ class RestAPI {
 			'expires_at'       => $serial_key->get_expire_date(),
 			'product_id'       => $serial_key->get_product_id(),
 			'product'          => $serial_key->get_product_title(),
-			'activations'      => $serial_key->get_activations(
-				array(
-					'limit'  => - 1,
-					'output' => ARRAY_A,
-				)
+			'activations'      => array_map(
+				static function ( $activation ) {
+					return $activation->to_array();
+				},
+				$serial_key->activations
 			),
 
 			// Deprecated.
@@ -365,11 +365,11 @@ class RestAPI {
 			'expires_at'       => $serial_key->get_expire_date(),
 			'product_id'       => $serial_key->get_product_id(),
 			'product'          => $serial_key->get_product_title(),
-			'activations'      => $serial_key->get_activations(
-				array(
-					'limit'  => - 1,
-					'output' => ARRAY_A,
-				)
+			'activations'      => array_map(
+				static function ( $activation ) {
+					return $activation->to_array();
+				},
+				$serial_key->activations
 			),
 
 			// Deprecated.

--- a/includes/Stocks.php
+++ b/includes/Stocks.php
@@ -61,7 +61,7 @@ class Stocks {
 			return; // Return if stock management is disabled.
 		}
 
-		$product = $key->get_product();
+		$product = $key->product;
 
 		// Check if product exists and stock management is enabled.
 		if ( ! $product || ! $product->get_manage_stock() ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -753,7 +753,7 @@ function wcsn_order_replace_key( $order_id, $product_id = null, $key_id = null )
 			$props['order_date']    = null;
 		}
 		$key->fill( $props );
-		if ( $key->save() ) {
+		if ( ! is_wp_error( $key->save() ) ) {
 			++$replaced;
 		}
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -422,7 +422,7 @@ function wcsn_order_get_unfulfilled_items( $order_id ) {
 	foreach ( $line_items as $line_item ) {
 		$qty = $line_item['quantity'];
 		foreach ( $keys as $key ) {
-			if ( $key->get_product_id() !== $line_item['product_id'] ) {
+			if ( $key->product_id !== $line_item['product_id'] ) {
 				continue;
 			}
 			// todo uncomment this when we will support for order item id.
@@ -600,8 +600,8 @@ function wcsn_order_update_keys( $order_id ) {
 
 	foreach ( $keys as $key ) {
 		$is_expired = $key->is_expired();
-		if ( $is_expired && 'expired' !== $key->get_status() ) {
-			$key->set_status( 'expired' );
+		if ( $is_expired && 'expired' !== $key->status ) {
+			$key->status = 'expired';
 			$key->save();
 		} elseif ( ! $is_expired && in_array(
 			$order_status,
@@ -610,11 +610,11 @@ function wcsn_order_update_keys( $order_id ) {
 				'complete',
 			),
 			true
-		) && 'sold' !== $key->get_status() ) {
-			$key->set_status( 'sold' );
+		) && 'sold' !== $key->status ) {
+			$key->status = 'sold';
 			$key->save();
-		} elseif ( 'on-hold' === $order_status && ! $is_expired && 'pending' !== $key->get_status() ) {
-			$key->set_status( 'pending' );
+		} elseif ( 'on-hold' === $order_status && ! $is_expired && 'pending' !== $key->status ) {
+			$key->status = 'pending';
 			$key->save();
 		} elseif ( in_array( $order_status, $revoke_statues, true ) && ! $is_expired && apply_filters( 'wc_serial_numbers_revoke_order_item_keys', true, $line_items, $order_id ) ) {
 			wcsn_order_remove_keys( $order_id );
@@ -1013,32 +1013,32 @@ function wcsn_get_key_display_properties( $key, $context = 'order_details' ) {
 	$properties = array(
 		'key'              => array(
 			'label'    => __( 'Key', 'wc-serial-numbers' ),
-			'value'    => '<code>' . $key->get_key() . '</code>',
+			'value'    => '<code>' . $key->key . '</code>',
 			'priority' => 10,
 		),
 		'activation_email' => array(
 			'label'    => __( 'Activation Email', 'wc-serial-numbers' ),
-			'value'    => $key->get_customer_email(),
+			'value'    => $key->customer_email,
 			'priority' => 20,
 		),
 		'activation_limit' => array(
 			'label'    => __( 'Activation Limit', 'wc-serial-numbers' ),
-			'value'    => ! empty( $key->get_activation_limit() ) ? number_format_i18n( $key->get_activation_limit() ) : __( 'None', 'wc-serial-numbers' ),
+			'value'    => ! empty( $key->activation_limit ) ? number_format_i18n( $key->activation_limit ) : __( 'None', 'wc-serial-numbers' ),
 			'priority' => 30,
 		),
 		'activation_count' => array(
 			'label'    => __( 'Activation Count', 'wc-serial-numbers' ),
-			'value'    => ! empty( $key->get_activation_count() ) ? number_format_i18n( $key->get_activation_count() ) : __( 'None', 'wc-serial-numbers' ),
+			'value'    => ! empty( $key->activation_count ) ? number_format_i18n( $key->activation_count ) : __( 'None', 'wc-serial-numbers' ),
 			'priority' => 40,
 		),
 		'expire_date'      => array(
 			'label'    => __( 'Expire Date', 'wc-serial-numbers' ),
-			'value'    => ! empty( $key->get_expire_date() ) ? $key->get_expire_date() : __( 'Lifetime', 'wc-serial-numbers' ),
+			'value'    => ! empty( $key->expire_date ) ? $key->expire_date : __( 'Lifetime', 'wc-serial-numbers' ),
 			'priority' => 50,
 		),
 		'status'           => array(
 			'label'    => __( 'Status', 'wc-serial-numbers' ),
-			'value'    => $key->get_status(),
+			'value'    => $key->status,
 			'priority' => 100,
 		),
 	);

--- a/tests/phpunit/KeyModelTest.php
+++ b/tests/phpunit/KeyModelTest.php
@@ -124,4 +124,19 @@ class KeyModelTest extends TestCase {
 		$limited->set_activation_count( 2 );
 		$this->assertSame( 3, $limited->get_activations_left() );
 	}
+
+	/**
+	 * Regression #527: find() returns null (not a non-existent object) for a
+	 * missing id. The admin edit screen must null-guard the result before
+	 * calling ->exists(), or it fatals on a stale/deleted edit link.
+	 */
+	public function testFindReturnsNullForMissingId(): void {
+		$this->assertNull( Key::find( 999999 ) );
+
+		$product = $this->create_product();
+		$key     = $this->make_available_key( $product->get_id(), 'FIND-ME' );
+		$found   = Key::find( $key->get_id() );
+		$this->assertInstanceOf( Key::class, $found );
+		$this->assertTrue( $found->exists() );
+	}
 }

--- a/tests/phpunit/ListTableQueryTest.php
+++ b/tests/phpunit/ListTableQueryTest.php
@@ -122,6 +122,58 @@ class ListTableQueryTest extends TestCase {
 	}
 
 	/**
+	 * The customer_id filter restricts results to keys on that customer's orders.
+	 *
+	 * Regression: keys have no customer column, so the filter must resolve the
+	 * customer to their order ids and apply an order_id IN (...) condition
+	 * (Key::prepare_customer_query). Without it the arg is silently dropped and
+	 * every key leaks into the filtered view and its per-status counts.
+	 */
+	public function testCustomerIdFilterRestrictsToCustomersKeys(): void {
+		$product    = $this->create_product();
+		$customer_a = $this->create_customer( 'a@example.com' );
+		$customer_b = $this->create_customer( 'b@example.com' );
+
+		$order_a = $this->create_order( $product, 1, array( 'customer_id' => $customer_a, 'status' => 'completed' ) );
+		$order_b = $this->create_order( $product, 1, array( 'customer_id' => $customer_b, 'status' => 'completed' ) );
+
+		Key::insert( array( 'product_id' => $product->get_id(), 'serial_key' => 'CUST-A1', 'status' => 'sold', 'order_id' => $order_a->get_id() ) );
+		Key::insert( array( 'product_id' => $product->get_id(), 'serial_key' => 'CUST-A2', 'status' => 'sold', 'order_id' => $order_a->get_id() ) );
+		Key::insert( array( 'product_id' => $product->get_id(), 'serial_key' => 'CUST-B1', 'status' => 'sold', 'order_id' => $order_b->get_id() ) );
+		$this->make_available_key( $product->get_id(), 'CUST-NONE' );
+
+		$items = Key::query( $this->table_args( array( 'customer_id' => $customer_a ) ) );
+
+		$this->assertCount( 2, $items );
+		foreach ( $items as $item ) {
+			$this->assertSame( $order_a->get_id(), $item->order_id );
+		}
+
+		$this->assertSame( 2, Key::count( array_merge( $this->table_args(), array( 'customer_id' => $customer_a ) ) ) );
+		$this->assertSame( 1, Key::count( array_merge( $this->table_args(), array( 'customer_id' => $customer_b ) ) ) );
+	}
+
+	/**
+	 * A customer with no orders resolves to an empty order-id list, which the
+	 * query layer ignores (empty IN is not a constraint). The filter therefore
+	 * falls through to the unfiltered result set rather than forcing zero rows.
+	 *
+	 * This pins the framework's empty-IN contract: in the admin the customer
+	 * filter is only reachable from an existing key, so this edge is benign.
+	 */
+	public function testCustomerIdFilterWithNoOrdersIsIgnored(): void {
+		$product = $this->create_product();
+		$this->make_available_key( $product->get_id(), 'CUST-X1' );
+		$this->make_available_key( $product->get_id(), 'CUST-X2' );
+		$customer = $this->create_customer( 'noorders@example.com' );
+
+		$items = Key::query( $this->table_args( array( 'customer_id' => $customer ) ) );
+
+		$this->assertCount( 2, $items );
+		$this->assertSame( 2, Key::count( array_merge( $this->table_args(), array( 'customer_id' => $customer ) ) ) );
+	}
+
+	/**
 	 * per_page/paged paginate into distinct slices like the table expects.
 	 */
 	public function testPerPagePagedPagination(): void {

--- a/tests/phpunit/ModelHooksTest.php
+++ b/tests/phpunit/ModelHooksTest.php
@@ -43,6 +43,23 @@ class ModelHooksTest extends TestCase {
 	}
 
 	/**
+	 * Inserting a key auto-enables serial numbers on its product.
+	 *
+	 * Regression: the b8 base fires `..._key_inserted` (passing the model), not
+	 * the legacy `..._key_insert` (passing an id). Actions::enable_product must
+	 * stay wired to the live hook so programmatic inserts (e.g. Pro CSV import)
+	 * still mark the product as serial-enabled.
+	 */
+	public function testKeyInsertEnablesProductViaHook(): void {
+		$product = $this->create_product( array( 'serial_enabled' => false ) );
+		$this->assertSame( '', get_post_meta( $product->get_id(), '_is_serial_number', true ) );
+
+		$this->make_available_key( $product->get_id(), 'HOOK-ENABLE-1' );
+
+		$this->assertSame( 'yes', get_post_meta( $product->get_id(), '_is_serial_number', true ) );
+	}
+
+	/**
 	 * key_updated fires with the model and only the changed columns.
 	 */
 	public function testUpdatedHookFiresWithChangedColumnsOnly(): void {

--- a/tests/phpunit/ProContractTest.php
+++ b/tests/phpunit/ProContractTest.php
@@ -142,6 +142,35 @@ class ProContractTest extends TestCase {
 	}
 
 	/**
+	 * Regression #532: the Pro "Export All" builds its query with product_id => 0
+	 * ("All Products") and no status. The query layer would treat 0 as a literal
+	 * product_id match and return nothing (blank CSV); Key::prepare_product_query
+	 * must drop the zero arg so every key is exported.
+	 */
+	public function testExportAllProductsAllStatusReturnsRows(): void {
+		$product_a = $this->create_product();
+		$product_b = $this->create_product();
+		$order     = $this->create_order( $product_a, 1, array( 'status' => 'completed' ) );
+
+		$this->make_available_key( $product_a->get_id(), 'EXP-ALL-A1' );
+		$sold = Key::insert(
+			array(
+				'product_id' => $product_b->get_id(),
+				'serial_key' => 'EXP-ALL-B1',
+				'status'     => 'sold',
+				'order_id'   => $order->get_id(),
+			)
+		);
+		$this->assertNotWPError( $sold );
+
+		// The exact arg shape the Pro export passes for All Products + All Status.
+		$results = Key::query( array( 'product_id' => 0, 'per_page' => 20, 'paged' => 1 ) );
+
+		$this->assertCount( 2, $results );
+		$this->assertSame( 2, Key::count( array( 'product_id' => 0 ) ) );
+	}
+
+	/**
 	 * Released Pro 1.4.6 builds its CSV-export date range as a legacy `where_query`
 	 * array of array( 'column', 'compare', 'value' ) clauses (Admin/Actions.php),
 	 * not the b8-native `order_date__between` modifier. The model must translate

--- a/tests/phpunit/RestApiValidateTest.php
+++ b/tests/phpunit/RestApiValidateTest.php
@@ -3,6 +3,7 @@
 
 namespace WooCommerceSerialNumbers\Tests;
 
+use WooCommerceSerialNumbers\Models\Activation;
 use WooCommerceSerialNumbers\Models\Key;
 
 /**
@@ -144,5 +145,37 @@ class RestApiValidateTest extends TestCase {
 		$this->assertArrayHasKey( 'activation_count', $data );
 		$this->assertArrayHasKey( 'activations_left', $data );
 		$this->assertArrayHasKey( 'expire_date', $data );
+	}
+
+	/**
+	 * Regression #531: the `activations` field must serialize as a list of
+	 * associative arrays (the documented contract the Legacy API add-on parses),
+	 * not model objects that JSON-encode to empty `{}` and fatal the client.
+	 */
+	public function testActivationsFieldSerializesAsArrays(): void {
+		list( $product, , $key ) = $this->make_bound_key( 'ACT-CONTRACT-1' );
+
+		$activation = Activation::insert(
+			array(
+				'serial_id' => $key->get_id(),
+				'instance'  => 'instance-1',
+				'platform'  => 'linux',
+			)
+		);
+		$this->assertNotWPError( $activation );
+
+		$response = rest_do_request( $this->get_rest_request( '/wcsn/validate', array( 'product_id' => $product->get_id(), 'serial_key' => 'ACT-CONTRACT-1' ) ) );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertIsArray( $data['activations'] );
+		$this->assertCount( 1, $data['activations'] );
+		$this->assertIsArray( $data['activations'][0], 'Each activation must be an array, not a model object.' );
+		$this->assertSame( 'instance-1', $data['activations'][0]['instance'] );
+		$this->assertSame( 'linux', $data['activations'][0]['platform'] );
+
+		// The whole payload must round-trip through JSON without emptying the activations.
+		$decoded = json_decode( wp_json_encode( $data ), true );
+		$this->assertSame( 'instance-1', $decoded['activations'][0]['instance'] );
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to the bytekit -> b8 model migration on `release/2.3.5`. Fixes regressions the migration introduced, closes the three v2.3.5 milestone bugs, and converts the free plugin's own code off the deprecated getter/setter shims onto the new property API. The deprecated shims themselves are intentionally kept — master Pro (1.4.6) and the Legacy API add-on still call them.

All changes verified against the PHPUnit suite (89 tests green) and phpcs (clean).

## Migration regressions

- **Keys "filter by customer" silently broken** — b8 dropped the old `customer_id` -> `order_id IN (...)` translation. Restored as a `query_args` filter on the Key model (honors the framework's empty-`IN`-is-ignored contract). +2 tests.
- **`enable_product` never fired** — the hook was `wc_serial_numbers_key_insert`, but b8 fires `wc_serial_numbers_key_inserted` and passes the model (not an id). Rewired and signature fixed. Removed three dead encrypt/decrypt action hooks the model now owns directly. +1 test.
- **`wcsn_order_replace_key` counted failed saves as success** — `save()` returns a truthy `WP_Error` on failure; now checks `! is_wp_error()`.

## v2.3.5 milestone bugs

- **#527 Edit key redirects / fatals** — `Key::find()` returns `null` for a missing id, so `! $key->exists()` fataled. Null-guarded the edit screen lookup. +1 test.
- **#531 Legacy API critical error** — the REST `activations` field returned model objects (which JSON-encode to `{}`); b8 ignores the old `ARRAY_A` output arg. Now mapped through `to_array()` to restore the documented array contract. +1 test (incl. JSON round-trip).
- **#532 Blank "Export All" CSV** — master Pro passes `product_id => 0` for "All Products", which b8 turns into `WHERE product_id = 0` (no rows). Fixed free-side (`Key::prepare_product_query` drops a zero `product_id`) so unmodified master Pro works. +1 test.

## Deprecated API -> property API conversion

Converted ~90 internal call sites across 11 files (REST, admin screens/list tables, templates, PDF integrations, core helpers) from `$key->get_*()` / `$key->set_*()` to property access (`$key->serial_key`, `$key->status = ...`, etc.). No behavior change; the deprecated methods remain for external consumers.

## Pro compatibility

Master Pro 1.4.6's full call surface into the free plugin (wcsn_* functions, Key/Activation getters, `where_query`, the generator/duplicate filters, the REST activations contract) is satisfied. The only break was #532, now fixed free-side.

Closes #527, #531, #532.
